### PR TITLE
Include attachments in quotes

### DIFF
--- a/src/handler/quoteHandler.ts
+++ b/src/handler/quoteHandler.ts
@@ -34,6 +34,7 @@ const getChannels = (channelIds: Array<string>, client: Client) => {
 const createQuoteMessage = (client: Client, quotedUser: User | undefined, quoter: User, quotedMessage: Message): MessageOptions => {
     return {
         embeds: [
+            ...quotedMessage.embeds,
             {
                 color: 0xFFC000,
                 description: quotedMessage.content,


### PR DESCRIPTION
Attachments from the original message are now included in the quote.
![image_quotes_censored](https://user-images.githubusercontent.com/40566146/137504271-b67552f9-d2ce-41cc-8c81-9c989297565f.png)
