### PR TITLE
Implement quote target channel overrides

### DIFF
--- a/config.template.json
+++ b/config.template.json
@@ -20,7 +20,8 @@
             "allowed_group_ids": [],
             "anonymous_channel_ids": [],
             "blacklisted_channel_ids": [],
-            "target_channel_ids": []
+            "target_channel_overrides": [],
+            "default_target_channel_id": ""
         }
     },
     "ids": {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -33,7 +33,8 @@ export interface Config {
             allowed_group_ids: Array<Snowflake>,
             anonymous_channel_ids: Array<Snowflake>,
             blacklisted_channel_ids: Array<Snowflake>,
-            target_channel_ids: Array<Snowflake>,
+            target_channel_overrides: { [key:string]:string },
+            default_target_channel_id: Snowflake,
             emoji_name: string,
         }
     },


### PR DESCRIPTION
Adds the ability to use a different output channel for quotes per source
channel by specifing target channel overrides:

```json
{
	"bot_settings": {
		"quotes": {
			"target_channel_overrides": {
				"source_channel_id": "target_channel_id",
				"another_source_channel": "another_target_channel"
			}
		}
	}
}
```

This enables things like having a separate channel for nsfw
quotes or simlar.

It is no longer possible to have multiple output channels per source
channel because that was useless anyway.

Breaking changes:

- the configuration option "bot_settings.quotes.target_channel_ids" was replaced with "bot_settings.quotes.default_target_channel_id"