### PR TITLE
Introduce Bot Context

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,6 +29,7 @@
          */
         "no-var": 2,                        // http://eslint.org/docs/rules/no-var
         "prefer-const": "error",
+        "arrow-parens": ["warn", "as-needed"],
         "prefer-destructuring": [2, {       // http://eslint.org/docs/rules/prefer-destructuring
             "array": false,
             "object": true

--- a/src/app.js
+++ b/src/app.js
@@ -62,11 +62,14 @@ const client = new Discord.Client({
         "REACTION",
         "USER"
     ],
-    /* allowedMentions: {
+    /*
+    allowedMentions: {
         parse: ["users", "roles"],
         repliedUser: true
-    }, */
-    intents: ["DIRECT_MESSAGES",
+    },
+    */
+    intents: [
+        "DIRECT_MESSAGES",
         "GUILDS",
         "GUILD_BANS",
         "GUILD_EMOJIS_AND_STICKERS",
@@ -78,7 +81,8 @@ const client = new Discord.Client({
         "GUILD_MESSAGE_TYPING",
         "GUILD_PRESENCES",
         "GUILD_VOICE_STATES",
-        "GUILD_WEBHOOKS"]
+        "GUILD_WEBHOOKS"
+    ]
 });
 
 // @ts-ignore

--- a/src/app.js
+++ b/src/app.js
@@ -35,6 +35,7 @@ import { assert } from "console";
 import { connectAndPlaySaufen } from "./handler/voiceHandler";
 import { reminderHandler } from "./commands/erinnerung";
 import { endAprilFools, startAprilFools } from "./handler/aprilFoolsHandler";
+import { createBotContext } from "./context";
 
 const version = conf.getVersion();
 const appname = conf.getName();
@@ -48,6 +49,9 @@ console.log(
     ` #${"-".repeat(splashPadding)}#\n\n` +
     ` Copyright (c) ${(new Date()).getFullYear()} ${devname}\n`
 );
+
+/** @type {BotContext} */
+let botContext;
 
 log.info("Started.");
 
@@ -125,11 +129,14 @@ const leetTask = async() => {
 
 let firstRun = true;
 
-client.on("ready", async(_client) => {
+client.on("ready", async(initializedClient) => {
     try {
         log.info("Running...");
         log.info(`Got ${client.users.cache.size} users, in ${client.channels.cache.size} channels of ${client.guilds.cache.size} guilds`);
         client.user.setActivity(config.bot_settings.status);
+
+        botContext = await createBotContext(initializedClient);
+        console.assert(!!botContext); // TODO: Remove once botContext is used
 
         // When the application is ready, slash commands should be registered
         await registerAllApplicationCommandsAsGuildCommands(client);

--- a/src/app.ts
+++ b/src/app.ts
@@ -131,7 +131,7 @@ const leetTask = async() => {
 
 let firstRun = true;
 
-client.on("ready", async(initializedClient) => {
+client.on("ready", async initializedClient => {
     try {
         log.info("Running...");
         log.info(`Got ${client.users.cache.size} users, in ${client.channels.cache.size} channels of ${client.guilds.cache.size} guilds`);
@@ -228,7 +228,7 @@ client.on("ready", async(initializedClient) => {
  * for the "old commands". This way we can easily migrate commands to slash commands
  * and still have the option to use the textual commands. Win-Win :cooldoge:
  */
-client.on("messageCreate", async(message) => {
+client.on("messageCreate", async message => {
     try {
         await messageCommandHandler(message, client, botContext);
     }
@@ -237,7 +237,7 @@ client.on("messageCreate", async(message) => {
     }
 });
 
-client.on("interactionCreate", async(interaction) => {
+client.on("interactionCreate", async interaction => {
     try {
         await handleInteractionEvent(interaction, client, botContext);
     }
@@ -289,7 +289,7 @@ client.on("messageCreate", async message => {
     }
 });
 
-client.on("messageDelete", async(message) => {
+client.on("messageDelete", async message => {
     try {
         await messageDeleteHandler(message as Message, client);
     }

--- a/src/app.ts
+++ b/src/app.ts
@@ -228,7 +228,7 @@ client.on("ready", async(initializedClient) => {
  */
 client.on("messageCreate", async(message) => {
     try {
-        await messageCommandHandler(message, client);
+        await messageCommandHandler(message, client, botContext);
     }
     catch (err) {
         log.error(`[messageCreate] Error on message ${message.id}. Cause: ${err}`);
@@ -237,7 +237,7 @@ client.on("messageCreate", async(message) => {
 
 client.on("interactionCreate", async(interaction) => {
     try {
-        await handleInteractionEvent(interaction, client);
+        await handleInteractionEvent(interaction, client, botContext);
     }
     catch (err) {
         log.error(`[interactionCreate] Error on interaction ${interaction.id}. Cause: ${err}`);
@@ -269,7 +269,7 @@ client.on("guildMemberAdd", async member => {
     });
 });
 
-client.on("guildMemberRemove", async(member) => {
+client.on("guildMemberRemove", async member => {
     try {
         await GuildRagequit.incrementRagequit(member.guild.id, member.id);
     }
@@ -278,16 +278,16 @@ client.on("guildMemberRemove", async(member) => {
     }
 });
 
-client.on("messageCreate", async(message) => {
+client.on("messageCreate", async message => {
     try {
-        await messageHandler(message, client);
+        await messageHandler(message, client, botContext);
     }
     catch (err) {
         log.error(`[messageCreate] Error on message ${message.id}. Cause: ${err}`);
     }
 });
 
-client.on("messageDelete", (message) => {
+client.on("messageDelete", message => {
     try {
         messageDeleteHandler(message as Message, client);
     }
@@ -298,7 +298,7 @@ client.on("messageDelete", (message) => {
 
 client.on("messageUpdate", async(_, newMessage) => {
     try {
-        await messageHandler(newMessage as Message, client);
+        await messageHandler(newMessage as Message, client, botContext);
     }
     catch (err) {
         log.error(`[messageUpdate] Error on message ${newMessage.id}. Cause: ${err}`);

--- a/src/app.ts
+++ b/src/app.ts
@@ -254,12 +254,12 @@ client.on("guildMemberAdd", async member => {
         return;
     }
 
-    if (member.roles.cache.has(botContext.roles.shame.id)) {
+    if (member.roles.cache.has(botContext.roles.shame_role.id)) {
         log.debug(`Member "${member.id}" already has the shame role, skipping`);
         return;
     }
 
-    await member.roles.add(botContext.roles.shame);
+    await member.roles.add(botContext.roles.shame_role);
 
     await botContext.mainChannel.send({
         content: `Haha, schau mal einer guck wer wieder hergekommen ist! <@${member.id}> hast es aber nicht lange ohne uns ausgehalten. ${numRagequits > 1 ? "Und das schon zum " + numRagequits + ". mal" : ""}`,

--- a/src/app.ts
+++ b/src/app.ts
@@ -87,7 +87,7 @@ const client = new Discord.Client({
 
 process.on("unhandledRejection", (err: any, promise) => log.error(`Unhandled rejection (promise: ${promise}, reason: ${err.stack})`));
 process.on("uncaughtException", (err, origin) => log.error(`Uncaught exception (origin: ${origin}, error: ${err})`));
-process.on("SIGTERM", (signal) => log.error(`Received Sigterm: ${signal}`));
+process.on("SIGTERM", signal => log.error(`Received Sigterm: ${signal}`));
 process.on("beforeExit", code => {
     log.warn(`Process will exit with code: ${code}`);
     process.exit(code);

--- a/src/app.ts
+++ b/src/app.ts
@@ -186,14 +186,14 @@ client.on("ready", async(initializedClient) => {
             // eslint-disable-next-line no-unused-vars
             const saufenJob = new Cron("36 0-23 * * FRI-SAT,SUN", async() => {
                 log.debug("Entered Saufen cronjob");
-                await connectAndPlaySaufen(_client);
+                await connectAndPlaySaufen(initializedClient);
             }, cronOptions);
 
             log.info("Scheduling Reminder Cronjob");
             // eslint-disable-next-line no-unused-vars
             const reminderJob = new Cron("* * * * *", async() => {
                 log.debug("Entered reminder cronjob");
-                await reminderHandler(_client);
+                await reminderHandler(initializedClient);
             }, cronOptions);
 
             // eslint-disable-next-line no-unused-vars

--- a/src/app.ts
+++ b/src/app.ts
@@ -85,8 +85,7 @@ const client = new Discord.Client({
     ]
 });
 
-// @ts-ignore
-process.on("unhandledRejection", (err, promise) => log.error(`Unhandled rejection (promise: ${promise}, reason: ${err.stack})`));
+process.on("unhandledRejection", (err: any, promise) => log.error(`Unhandled rejection (promise: ${promise}, reason: ${err.stack})`));
 process.on("uncaughtException", (err, origin) => log.error(`Uncaught exception (origin: ${origin}, error: ${err})`));
 process.on("SIGTERM", (signal) => log.error(`Received Sigterm: ${signal}`));
 process.on("beforeExit", code => {
@@ -255,31 +254,14 @@ client.on("guildMemberAdd", async member => {
         return;
     }
 
-    if (member.roles.cache.has(config.ids.shame_role_id)) {
+    if (member.roles.cache.has(botContext.roles.shame.id)) {
         log.debug(`Member "${member.id}" already has the shame role, skipping`);
         return;
     }
 
-    const shameRole = member.guild.roles.cache.get(config.ids.shame_role_id);
-    if (!shameRole) {
-        log.error(`Shame role not found: "${config.ids.shame_role_id}"`);
-        return;
-    }
+    await member.roles.add(botContext.roles.shame);
 
-    member.roles.add(shameRole);
-
-    const hauptchat = member.guild.channels.cache.get(config.ids.hauptchat_id);
-    if (!hauptchat) {
-        log.error(`Could not find hauptChat. Fix your stuff. Looked or guild with it: "${config.ids.hauptchat_id}"`);
-        return;
-    }
-
-    if (hauptchat.type !== "GUILD_TEXT") {
-        log.error(`Hauptchat is of unsupported type "${hauptchat.type}"`);
-        return;
-    }
-
-    hauptchat.send({
+    await botContext.mainChannel.send({
         content: `Haha, schau mal einer guck wer wieder hergekommen ist! <@${member.id}> hast es aber nicht lange ohne uns ausgehalten. ${numRagequits > 1 ? "Und das schon zum " + numRagequits + ". mal" : ""}`,
         allowedMentions: {
             users: [member.id]

--- a/src/commands/bonk.ts
+++ b/src/commands/bonk.ts
@@ -50,8 +50,8 @@ Usage: ${config.bot_settings.prefix.command_prefix}bonk
         else {
             toBeBonked = message.author;
         }
-        const meme = await createBonkMeme(toBeBonked);
 
+        const meme = await createBonkMeme(toBeBonked);
         try {
             await message.channel.send({
                 files: [{

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -1,8 +1,9 @@
 /* eslint-disable no-use-before-define */
+import { MessageComponentInteraction } from "discord.js";
 import { SlashCommandBuilder /* , SlashCommandOptionsOnlyBuilder, SlashCommandSubcommandsOnlyBuilder */ } from "@discordjs/builders";
 import type { ApplicationCommandPermissionType, Client, CommandInteraction } from "discord.js";
 import type { ProcessableMessage } from "../handler/cmdHandler";
-import {MessageComponentInteraction} from "discord.js";
+import type { BotContext } from "../context";
 
 // A command can be an application command (slash command) or a message command or both
 export type Command = ApplicationCommand | MessageCommand | SpecialCommand;
@@ -29,7 +30,8 @@ export interface UserInteraction {
     readonly name: string;
     handleInteraction(
         command: MessageComponentInteraction,
-        client: Client
+        client: Client,
+        context: BotContext
     ): Promise<void>;
 }
 
@@ -41,21 +43,22 @@ interface AppCommand {
     applicationCommand: Pick<SlashCommandBuilder, "toJSON">;
     handleInteraction(
         command: CommandInteraction,
-        client: Client
+        client: Client,
+        context: BotContext
     ): Promise<CommandResult>;
 }
 
 // For a MessageCommand we require an additional modCommand property and a handler method
 interface MsgCommand {
-    handleMessage(message: ProcessableMessage, client: Client): Promise<CommandResult>;
+    handleMessage(message: ProcessableMessage, client: Client, context: BotContext): Promise<CommandResult>;
 }
 
 // For SpecialCommands we require a pattern and a randomness (<= 1)
 interface SpcalCommand {
     randomness: number;
     cooldownTime?: number;
-    handleSpecialMessage(message: ProcessableMessage, client: Client): Promise<CommandResult>;
-    matches(message: ProcessableMessage): boolean;
+    handleSpecialMessage(message: ProcessableMessage, client: Client, context: BotContext): Promise<CommandResult>;
+    matches(message: ProcessableMessage, context: BotContext): boolean;
 }
 
 export function isApplicationCommand(cmd: Command): cmd is ApplicationCommand {

--- a/src/commands/erinnerung.ts
+++ b/src/commands/erinnerung.ts
@@ -19,6 +19,7 @@ export class ErinnerungCommand implements MessageCommand {
             await message.reply("Brudi ich muss schon wissen wann ich dich erinnern soll");
             return;
         }
+
         try {
             const date = Sugar.Date.create(param, {
                 locale: "de",

--- a/src/commands/erinnerung.ts
+++ b/src/commands/erinnerung.ts
@@ -92,6 +92,6 @@ export const reminderHandler = async(client: Client) => {
         }
     }
     catch(err) {
-        logger.error(`Couldn't retreive reminders because of ${err}`);
+        logger.error(`Couldn't retrieve reminders because of ${err}`);
     }
 };

--- a/src/commands/geburtstag.ts
+++ b/src/commands/geburtstag.ts
@@ -33,18 +33,18 @@ export class GeburtstagCommand implements ApplicationCommand {
 
         const date = moment(`${month}-${day}`, "MM-DD");
 
-        if(date.isValid()) {
-            try {
-                await Birthday.insertBirthday(command.user.id, day, month);
-                command.reply("Danke mein G, ich hab dein Geburtstag eingetragen!");
-            }
-            catch(err) {
-                log.error(err);
-                command.reply("Shit, da ist was schief gegangen - hast du deinen Geburtstag schon eingetragen und bist so dumm das jetzt nochmal zu machen? Piss dich.");
-            }
-        }
-        else {
+        if(!date.isValid()) {
             await command.reply("Ach komm, für wie blöd hältst du mich?");
+            return;
+        }
+
+        try {
+            await Birthday.insertBirthday(command.user.id, day, month);
+            command.reply("Danke mein G, ich hab dein Geburtstag eingetragen!");
+        }
+        catch(err) {
+            log.error(err);
+            command.reply("Shit, da ist was schief gegangen - hast du deinen Geburtstag schon eingetragen und bist so dumm das jetzt nochmal zu machen? Piss dich.");
         }
     }
 }

--- a/src/commands/poll.js
+++ b/src/commands/poll.js
@@ -234,7 +234,7 @@ export const importPolls = async() => {
  * Initialized crons for delayed polls
  * @param {import("discord.js").Client} client
  */
-export const startCron = (client) => {
+export const startCron = client => {
     log.info("Scheduling Poll Cronjob...");
 
     // eslint-disable-next-line no-unused-vars
@@ -263,7 +263,7 @@ export const startCron = (client) => {
                         (x, index) => `${LETTERS[index]} ${
                             delayedPoll.reactionMap[index]
                         } (${x.length}):
-${x.map((uid) => users[uid]).join("\n")}\n\n`
+${x.map(uid => users[uid]).join("\n")}\n\n`
                     )
                     .join("")}
 `,
@@ -274,7 +274,7 @@ ${x.map((uid) => users[uid]).join("\n")}\n\n`
                 },
                 footer: {
                     text: `Gesamtabstimmungen: ${delayedPoll.reactions
-                        .map((x) => x.length)
+                        .map(x => x.length)
                         .reduce((a, b) => a + b)}`
                 }
             };

--- a/src/context.ts
+++ b/src/context.ts
@@ -6,6 +6,8 @@ import type { Config } from "./types";
  * Object that's passed to every executed command to make it easier to access common channels without repeatedly retrieving stuff via IDs.
  */
 export interface BotContext {
+    /** Initialized client, which guarantees the `user` being set. */
+    client: Client<true>;
     /** Avoid using the raw config. If the value must be ensured before (for example, the existence of a channel), consider adding it to the context. */
     rawConfig: Config;
     guild: Guild;
@@ -45,6 +47,7 @@ export async function createBotContext(client: Client<true>): Promise<BotContext
     }
 
     return {
+        client,
         rawConfig: config,
         guild,
         mainChannel,

--- a/src/context.ts
+++ b/src/context.ts
@@ -2,8 +2,11 @@ import type { Client, Guild, TextBasedChannel, VoiceChannel } from "discord.js";
 import { getConfig } from "./utils/configHandler";
 import type { Config } from "./types";
 
-
+/**
+ * Object that's passed to every executed command to make it easier to access common channels without repeatedly retrieving stuff via IDs.
+ */
 export interface BotContext {
+    /** Avoid using the raw config. If the value must be ensured before (for example, the existence of a channel), consider adding it to the context. */
     rawConfig: Config;
     guild: Guild;
     mainChannel: TextBasedChannel;
@@ -21,7 +24,7 @@ export async function createBotContext(client: Client<true>): Promise<BotContext
     const config = getConfig();
 
     const guild = client.guilds.cache.get(config.ids.guild_id);
-    if(!guild) {
+    if (!guild) {
         throw new Error(`Cannot find configured guild "${config.ids.guild_id}"`);
     }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,0 +1,54 @@
+import type { Client, Guild, TextBasedChannel, VoiceChannel } from "discord.js";
+import { getConfig } from "./utils/configHandler";
+import type { Config } from "./types";
+
+
+export interface BotContext {
+    rawConfig: Config;
+    guild: Guild;
+    mainChannel: TextBasedChannel;
+    mainVoiceChannel: VoiceChannel;
+
+    prefix: {
+        command: string;
+        modCommand: string;
+    };
+
+    // TODO: Add some user assertions like isMod and isTrusted
+}
+
+export async function createBotContext(client: Client<true>): Promise<BotContext> {
+    const config = getConfig();
+
+    const guild = client.guilds.cache.get(config.ids.guild_id);
+    if(!guild) {
+        throw new Error(`Cannot find configured guild "${config.ids.guild_id}"`);
+    }
+
+    const mainChannel = guild.channels.cache.get(config.ids.hauptchat_id);
+    if (!mainChannel) {
+        throw new Error(`Could not find main channel with id "${config.ids.hauptchat_id}" on guild "${guild.id}"`);
+    }
+    if (mainChannel.type !== "GUILD_TEXT") {
+        throw new Error(`Main channel is not a text channel. "${mainChannel.id}" is "${mainChannel.type}"`);
+    }
+
+    const mainVoiceChannel = guild.channels.cache.get(config.ids.haupt_woischat_id);
+    if (!mainVoiceChannel) {
+        throw new Error(`Could not find main voice channel with id "${config.ids.haupt_woischat_id}" on guild "${guild.id}"`);
+    }
+    if (mainVoiceChannel.type !== "GUILD_VOICE") {
+        throw new Error(`Main channel is not a text channel. "${mainVoiceChannel.id}" is "${mainVoiceChannel.type}"`);
+    }
+
+    return {
+        rawConfig: config,
+        guild,
+        mainChannel,
+        mainVoiceChannel,
+        prefix: {
+            command: config.bot_settings.prefix.command_prefix,
+            modCommand: config.bot_settings.prefix.mod_prefix
+        }
+    };
+}

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,4 @@
-import type { Client, Guild, TextBasedChannel, VoiceChannel } from "discord.js";
+import type { Client, Guild, Role, TextBasedChannel, VoiceChannel } from "discord.js";
 import { getConfig } from "./utils/configHandler";
 import type { Config } from "./types";
 
@@ -17,6 +17,9 @@ export interface BotContext {
     prefix: {
         command: string;
         modCommand: string;
+    };
+    roles: {
+        shame: Role;
     };
 
     // TODO: Add some user assertions like isMod and isTrusted
@@ -46,6 +49,12 @@ export async function createBotContext(client: Client<true>): Promise<BotContext
         throw new Error(`Main channel is not a text channel. "${mainVoiceChannel.id}" is "${mainVoiceChannel.type}"`);
     }
 
+    // TODO: Automate this and use a proper type mapping for all roles
+    const shameRole = guild.roles.cache.get(config.ids.shame_role_id);
+    if (!shameRole) {
+        throw new Error(`Shame role not found: "${config.ids.shame_role_id}"`);
+    }
+
     return {
         client,
         rawConfig: config,
@@ -55,6 +64,9 @@ export async function createBotContext(client: Client<true>): Promise<BotContext
         prefix: {
             command: config.bot_settings.prefix.command_prefix,
             modCommand: config.bot_settings.prefix.mod_prefix
+        },
+        roles: {
+            shame: shameRole
         }
     };
 }

--- a/src/handler/cmdHandler.ts
+++ b/src/handler/cmdHandler.ts
@@ -10,6 +10,7 @@ import { CommandFunction, CommandResult } from "../types";
 import log from "../utils/logger";
 import { getConfig } from "../utils/configHandler";
 import * as ban from "../commands/modcommands/ban";
+import type { BotContext } from "../context";
 
 const config = getConfig();
 
@@ -30,7 +31,7 @@ export function isProcessableMessage(message: Message): message is ProcessableMe
  * Passes commands to the correct executor
  *
  */
-export default async function(message: Message, client: Client, isModCommand: boolean): Promise<CommandResult> {
+export default async function(message: Message, client: Client, isModCommand: boolean, context: BotContext): Promise<CommandResult> {
     if (message.author.bot) return;
 
     const cmdPrefix = isModCommand
@@ -107,7 +108,7 @@ export default async function(message: Message, client: Client, isModCommand: bo
     );
 
     try {
-        const response = await usedCommand.run(client, message, args);
+        const response = await usedCommand.run(client, message, args, context);
 
         // Non-Exception Error returned by the command (e.g.: Missing Argument)
         return response;

--- a/src/handler/cmdHandler.ts
+++ b/src/handler/cmdHandler.ts
@@ -81,7 +81,7 @@ export default async function(message: Message, client: Client, isModCommand: bo
 
     if (
         isModCommand &&
-        !message.member.roles.cache.some((r) =>
+        !message.member.roles.cache.some(r =>
             config.bot_settings.moderator_roles.includes(r.name)
         )
     ) {
@@ -91,7 +91,7 @@ export default async function(message: Message, client: Client, isModCommand: bo
 
         if (
             message.member.roles.cache.some(
-                (r) => r.id === config.ids.banned_role_id
+                r => r.id === config.ids.banned_role_id
             )
         ) {
             return "Da haste aber Schwein gehabt";

--- a/src/handler/commandHandler.ts
+++ b/src/handler/commandHandler.ts
@@ -118,7 +118,7 @@ export const registerAllApplicationCommandsAsGuildCommands = async(client: Clien
 
     const rest = new REST({version: "9"}).setToken(token);
 
-    const commandData = applicationCommands.map((cmd) =>
+    const commandData = applicationCommands.map(cmd =>
         ({
             ...cmd.applicationCommand.toJSON(),
             default_permission: cmd.permissions ? cmd.permissions.length === 0 : true
@@ -136,7 +136,7 @@ export const registerAllApplicationCommandsAsGuildCommands = async(client: Clien
         }) as { id: string, name: string }[];
 
         // Get commands that have permissions
-        const permissionizedCommands = applicationCommands.filter((cmd) => cmd.permissions && cmd.permissions.length > 0);
+        const permissionizedCommands = applicationCommands.filter(cmd => cmd.permissions && cmd.permissions.length > 0);
 
         // Create a request body for the permissions
         const permissionsToPost: GuildApplicationCommandPermissionData[] = createdCommands
@@ -169,7 +169,7 @@ const commandInteractionHandler = (
     context: BotContext
 ): Promise<unknown> => {
     const matchingCommand = applicationCommands.find(
-        (cmd) => cmd.name === command.commandName
+        cmd => cmd.name === command.commandName
     );
     if (matchingCommand) {
         log.debug(`Found a matching command ${matchingCommand.name}`);
@@ -193,7 +193,7 @@ const messageComponentInteractionHandler = (
     context: BotContext
 ): Promise<unknown> => {
     const matchingInteraction = interactions.find(
-        (cmd) => cmd.ids.find(id => id === command.customId
+        cmd => cmd.ids.find(id => id === command.customId
         ));
     if (matchingInteraction) {
         log.debug(`Found a matching interaction ${matchingInteraction.name}`);
@@ -287,12 +287,12 @@ const isCooledDown = (command: SpecialCommand) => {
 };
 
 const specialCommandHandler = (message: ProcessableMessage, client: Client, context: BotContext): Promise<unknown> => {
-    const commandCandidates = specialCommands.filter((p) => p.matches(message, context));
+    const commandCandidates = specialCommands.filter(p => p.matches(message, context));
     return Promise.all(
         commandCandidates
-            .filter((c) => Math.random() <= c.randomness)
-            .filter((c) => isCooledDown(c))
-            .map((c) => {
+            .filter(c => Math.random() <= c.randomness)
+            .filter(c => isCooledDown(c))
+            .map(c => {
                 log.info(
                     `User "${message.author.tag}" (${message.author}) performed special command: ${c.name}`
                 );

--- a/src/handler/fadingMessageHandler.ts
+++ b/src/handler/fadingMessageHandler.ts
@@ -6,8 +6,8 @@ let isLooping = false;
 
 const fadingMessageDeleteLoop = async(client: Client) => {
     const fadingMessages = await FadingMessage.findAll();
+    const currentTime = new Date();
     for (const fadingMessage of fadingMessages) {
-        const currentTime = new Date();
         if (currentTime < fadingMessage.endTime) {
             continue;
         }

--- a/src/handler/messageDeleteHandler.ts
+++ b/src/handler/messageDeleteHandler.ts
@@ -10,11 +10,11 @@ const deleteInlineRepliesFromBot = (
     Promise.allSettled(
         messageRef.channel.messages.cache
             .filter(
-                (m) =>
+                m =>
                     m.author.id === client.user!.id &&
                     m.reference?.messageId === messageRef.id
             )
-            .map((m) => m.delete())
+            .map(m => m.delete())
     );
 
 export default async function(message: Message, client: Client) {

--- a/src/handler/messageHandler.ts
+++ b/src/handler/messageHandler.ts
@@ -1,4 +1,5 @@
 import type { Client, ClientUser, Message } from "discord.js";
+import type { BotContext } from "../context";
 import { getConfig } from "../utils/configHandler";
 
 import cmdHandler from "./cmdHandler";
@@ -9,7 +10,7 @@ const getInlineReplies = (messageRef: Message, clientUser: ClientUser) => {
     return messageRef.channel.messages.cache.filter(m => m.author.id === clientUser.id && m.reference?.messageId === messageRef.id);
 };
 
-export default async function(message: Message, client: Client) {
+export default async function(message: Message, client: Client, context: BotContext) {
     const nonBiased = message.content
         .replace(config.bot_settings.prefix.command_prefix, "")
         .replace(config.bot_settings.prefix.mod_prefix, "")
@@ -47,7 +48,7 @@ export default async function(message: Message, client: Client) {
         return;
     }
 
-    const response = await cmdHandler(message, client, isModCommand);
+    const response = await cmdHandler(message, client, isModCommand, context);
 
     // Get all inline replies to the message and delete them. Ignore errors, since cached is used and previously deleted messages are contained as well
     getInlineReplies(message, client.user!).forEach(msg => msg.delete().catch(() => { return; }));

--- a/src/handler/voiceHandler.ts
+++ b/src/handler/voiceHandler.ts
@@ -43,21 +43,23 @@ export async function connectAndPlaySaufen(client: Client) {
     const csz = client.guilds.cache.get(cszId)!;
     const wois = csz.channels.cache.get(woisId) as VoiceChannel;
 
-    if (wois.members.size > 0) {
-        const files = await readdir(soundDir);
-        const randomSound = files[Math.floor(Math.random() * files.length)];
-        const file = path.resolve(soundDir, randomSound);
-        try {
-            const duration = (await gad.getAudioDurationInSeconds(file)) * 1000;
-            await playSaufen(file, duration);
-            const connection = await connectToHauptwois(wois);
-            connection.subscribe(player);
+    if (wois.members.size <= 0) {
+        return;
+    }
 
-            await setTimeout(duration);
-            connection.disconnect();
-        }
-        catch(err) {
-            logger.error("Could not play saufen", err);
-        }
+    const files = await readdir(soundDir);
+    const randomSound = files[Math.floor(Math.random() * files.length)];
+    const file = path.resolve(soundDir, randomSound);
+    try {
+        const duration = (await gad.getAudioDurationInSeconds(file)) * 1000;
+        await playSaufen(file, duration);
+        const connection = await connectToHauptwois(wois);
+        connection.subscribe(player);
+
+        await setTimeout(duration);
+        connection.disconnect();
+    }
+    catch(err) {
+        logger.error("Could not play saufen", err);
     }
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 import type { Snowflake, Client } from "discord.js";
+import type { BotContext } from "./context";
 import type { ProcessableMessage } from "./handler/cmdHandler";
 
 /**
@@ -7,7 +8,7 @@ import type { ProcessableMessage } from "./handler/cmdHandler";
  */
 export type CommandResult = string | void;
 
-export type CommandFunction = (client: Client, message: ProcessableMessage, args: Array<string>) => Promise<CommandResult>;
+export type CommandFunction = (client: Client, message: ProcessableMessage, args: Array<string>, context: BotContext) => Promise<CommandResult>;
 
 export type Mutable<T> = { -readonly [P in keyof T]: T[P] };
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -19,6 +19,23 @@ export interface GitHubContributor {
     contributions: number
 }
 
+export type ConfigRoleName =
+    | "banned_channel_id"
+    | "banned_role_id"
+    | "bday_role_id"
+    | "bot_log_channel_id"
+    | "default_role_id"
+    | "gruendervaeter_banned_role_id"
+    | "gruendervaeter_role_id"
+    | "guild_id"
+    | "haupt_woischat_id"
+    | "hauptchat_id"
+    | "shame_role_id"
+    | "trusted_banned_role_id"
+    | "trusted_role_id"
+    | "votes_channel_id"
+    | "woisgang_role_id";
+
 export interface Config {
     auth: {
         bot_token: string,
@@ -49,7 +66,7 @@ export interface Config {
         },
         flame_trusted_user_on_bot_ping: boolean
     },
-    ids: Record<string, Snowflake>
+    ids: Record<ConfigRoleName, Snowflake>
 }
 
 // eslint-disable-next-line no-use-before-define

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -19,7 +19,7 @@ export interface GitHubContributor {
     contributions: number
 }
 
-export type ConfigRoleName =
+export type ConfigRoleKey =
     | "banned_channel_id"
     | "banned_role_id"
     | "bday_role_id"
@@ -66,7 +66,7 @@ export interface Config {
         },
         flame_trusted_user_on_bot_ping: boolean
     },
-    ids: Record<ConfigRoleName, Snowflake>
+    ids: Record<ConfigRoleKey, Snowflake>
 }
 
 // eslint-disable-next-line no-use-before-define

--- a/src/utils/configHandler.ts
+++ b/src/utils/configHandler.ts
@@ -27,7 +27,7 @@ export const getConfig = function(): Config {
         process.exit(1);
     }
 
-    let jsondata = "";
+    let jsondata;
     try {
         jsondata = fs.readFileSync(configPath, "utf8");
     }

--- a/src/utils/configHandler.ts
+++ b/src/utils/configHandler.ts
@@ -4,56 +4,38 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import { Config } from "../types";
+import type { Config } from "../types";
 
 import log from "../utils/logger";
 
-const packagefile = require(path.resolve("package.json"));
+const packageFile = require(path.resolve("package.json"));
 const configPath = path.resolve("config.json");
 
-const isValidJson = (obj: any): Boolean => {
-    try {
-        JSON.parse(obj);
-    }
-    catch (e) {
-        return false;
-    }
-    return true;
-};
-
-export const getConfig = function(): Config {
+export const getConfig = () => {
     if (!fs.existsSync(configPath)) {
         log.error("Config does not exist! Make sure you copy config.template.json and paste it as 'config.json'. Then configure it.");
         process.exit(1);
     }
 
-    let jsondata;
+    let jsonString;
     try {
-        jsondata = fs.readFileSync(configPath, "utf8");
+        jsonString = fs.readFileSync(configPath, "utf8");
     }
     catch (e) {
-        log.error(`Cannot read config file: ${e}`);
+        log.error("Cannot read config file:", e);
         process.exit(1);
     }
 
-    if (isValidJson(jsondata)) return JSON.parse(jsondata);
-
-    log.error("Config is not valid JSON. Stopping...");
-    return process.exit(1);
+    try {
+        return JSON.parse(jsonString) as Config;
+    }
+    catch (e) {
+        log.error("Config is not valid JSON. Stopping...", e);
+        return process.exit(1);
+    }
 };
 
-export const getVersion = (): string => {
-    return packagefile.version;
-};
-
-export const getName = (): string => {
-    return packagefile.name;
-};
-
-export const getAuthor = (): string => {
-    return packagefile.author;
-};
-
-export const getDescription = (): string => {
-    return packagefile.description;
-};
+export const getVersion = () => packageFile.version;
+export const getName = () => packageFile.name;
+export const getAuthor = () => packageFile.author;
+export const getDescription = () => packageFile.description;

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -8,7 +8,7 @@ export function countWords(str: string): number {
 }
 
 /**
- * Get a substring after the first occurence of s
+ * Get a substring after the first occurrence of s
  * @param str string to search in
  * @param s search
  * @returns substring (untrimmed!)


### PR DESCRIPTION
Dieser PR ist noch ein draft. Idee:

Beim Anwendungsstart wird ein BotContext erstellt, der häufig verwendete Dinge liest und sicherstellt (z. B., dass der Hauptchat oder Rollen existieren). Man kann dann anschließend die wichtigsten Channels direkt aus dem Context holen, ohne, dass man sie aus dem Channel-Cache holen muss. Oder dass der Discord-Client `ready` ist, womit dann auch der Client-User Non-Null ist.

Statt
```js
const hauptchat = client.guilds.cache.get(config.guild_id)?.channels.cache.get(config.ids.hauptchat_id);
if (!hauptchat) {
    throw new Error("No hauptchat found");
}
await hauptchat.send("hallo");
```
wird nur noch
```js
const hauptchat = context.mainChannel;
await hauptchat.send("hallo");
```
geschrieben (mainChannel ist auch garantiert non-null und wird beim Anwendungsstart geholt). Das gleiche gilt für alle in der Config definierten Rollen. Die Anwendung startet nicht, wenn ein Channel oder Rollen anhand von den konfigurierten IDs nicht gefunden werden.

Der Context wird dann irgendwann an die Command handler übergeben, die diesen dann verwenden können. Redundante Checks sollen auf Typebene überflüssig gemacht und Boilerplate-Code reduziert werden.

Setzt natürlich voraus, dass Rollen und Channels gültig sind, solange die Anwendung läuft.

Langfristiges Ziel wäre, das Config-Signleton (`import { getConfig } from "../configFoo"; const config = getConfig();`) durch den Context abzulösen (der die Config auch zum "roh" lesen beinhaltet). Die Context-Instanz wird dann immer mitgegeben. Stellt auch sicher, dass ein Teil nur aufgerufen werden kann, wenn ein initialisierter Client vorhanden ist.

Als ersten Schritt könnte man die Commands so lassen, wie sie sind, und nach und nach migrieren.

Basiert auf #208 und #222, also frühstens irgendwann danach mergebar.