### PR TITLE
Fix sdm on reply when arguments are given

### DIFF
--- a/src/commands/sdm.ts
+++ b/src/commands/sdm.ts
@@ -138,7 +138,7 @@ export class SdmCommand implements MessageCommand, ApplicationCommand {
         }
 
         let question = args.join(" ").replace(/\s\s+/g, " ");
-        if (isReply) {
+        if (isReply && !args.length) {
             question = (await message.channel.messages.fetch(replyRef!)).content.trim();
         }
 


### PR DESCRIPTION
altes verhalten:
wenn man auf einen text antwortet, aber sdm argumente liefer, nimmt der bot den darauf geantworteten text
neues verhalten:
sdm bevorzugt *immer* argumente ueber antwort

achja und bitte hacktoberfest adden <3