### PR TITLE
Lessen the occurrence of the zig reaction

### DIFF
--- a/src/commands/special/keyword_react.ts
+++ b/src/commands/special/keyword_react.ts
@@ -8,14 +8,15 @@ import { SpecialCommand, CommandResult } from "../command.js";
 export class TriggerReactOnKeyword implements SpecialCommand {
     name: string = "ReactTrigger";
     description: string = "Trigger a Bot reaction on keyword";
-    randomness = 0.2;
+    randomness: number;
     cooldownTime = 300000;
     keyword: string;
     emoteName: string;
 
-    constructor(keyword: string, emoteName: string) {
+    constructor(keyword: string, emoteName: string, randomness: number = 0.2) {
         this.keyword = keyword;
         this.emoteName = emoteName;
+        this.randomness = randomness;
     }
 
     matches(message: ProcessableMessage): boolean {

--- a/src/handler/commandHandler.ts
+++ b/src/handler/commandHandler.ts
@@ -74,7 +74,7 @@ const config = getConfig();
 export const commands: readonly Command[] = [
     new InfoCommand(),
     new TriggerReactOnKeyword("nix", "nixos"),
-    new TriggerReactOnKeyword("zig", "zig"),
+    new TriggerReactOnKeyword("zig", "zig", 0.05),
     new WhereCommand(),
     new DadJokeCommand(),
     new WatCommand(),


### PR DESCRIPTION
Da zig zu oft vorkommt da eben auch Saetze mit `witzig` oder `~zig` (in ausgeschriebenen nummern) vorkommt, macht es potentiell sinn die Anzahl der Reactions zu vierteln.