### PR TITLE
Fix ban msg

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
             pkg-config
             cairo
             pango
+            biome
           ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
             CoreText
           ]);

--- a/src/service/banService.ts
+++ b/src/service/banService.ts
@@ -91,10 +91,7 @@ export async function banUser(
         const unbannedAtMessage =
             durationInHours === 0 || durationInHours === null
                 ? "Du wirst manuell durch einen Moderader entbannt"
-                : `Du wirst entbannt ${time(
-                      Date.now() + durationInHours * 60 * 60 * 1000,
-                      TimestampStyles.RelativeTime,
-                  )}`;
+                : `Du wirst entbannt in: ${time(unbanAt, TimestampStyles.RelativeTime)}`;
 
         await member.send(`Du hast dich selber von der Coding Shitpost Zentrale gebannt!
 ${unbannedAtMessage}

--- a/src/service/banService.ts
+++ b/src/service/banService.ts
@@ -89,9 +89,12 @@ export async function banUser(
     const nagChannel = context.textChannels.banned;
     if (isSelfBan) {
         const unbannedAtMessage =
-            durationInHours === 0 || durationInHours === null
+            unbanAt === null
                 ? "Du wirst manuell durch einen Moderader entbannt"
-                : `Du wirst entbannt in: ${time(unbanAt, TimestampStyles.RelativeTime)}`;
+                : `Du wirst entbannt ${time(
+                      unbanAt,
+                      TimestampStyles.RelativeTime,
+                  )}`;
 
         await member.send(`Du hast dich selber von der Coding Shitpost Zentrale gebannt!
 ${unbannedAtMessage}


### PR DESCRIPTION
`unbanAt` existiert bereits, warum nicht reusen?
Die Nachricht war ebenfalls malformed. Ebenfalls fixed.