### PR TITLE
fix insta regex

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
             pango
             biome
             nodejs_22
+            typescript
           ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
             CoreText
           ]);

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
             cairo
             pango
             biome
+            nodejs_22
           ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
             CoreText
           ]);

--- a/src/commands/instagram.ts
+++ b/src/commands/instagram.ts
@@ -5,7 +5,7 @@ import type { BotContext } from "../context.js";
 import * as instagramService from "../service/instagramService.js";
 
 const instagramOptions = {
-    uriPattern: /(?<uri>https?:\/\/(www\.)?instagram\.com\/(?:reel|tv|p)\/.*)\/.*/i,
+    uriPattern: /(?<uri>https?:\/\/(www\.)?instagram\.com\/(?:reel|tv|p)\/.*)\/?.*/i,
     headers: {
         "User-Agent":
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.124 Safari/537.36 Edg/102.0.1245.44",


### PR DESCRIPTION
pulling in node deps causes pre-commit hook to fail as well.
biome pulled in as node dependency will just not work running nix, because it relies on dynamic linking, which obviously will lead for any system not adhering to the standard FHS to fail. 

FUCK JS TOOLING IT'S SO BAD