### PR TITLE
woisvote: avoid double punctations in case reason has one already

### DIFF
--- a/src/commands/woisvote.ts
+++ b/src/commands/woisvote.ts
@@ -35,7 +35,7 @@ const createWoisMessage = async (
         `${woisVoteConstant}\nWois in ${time(
             date,
             TimestampStyles.ShortDateTime,
-        )}. Grund: ${reason}. Bock?`,
+        )}. Grund: ${reason}${/[\.!\?]$/.test(reason) ? "" : "."} Bock?`,
     );
     await woisMessage.react("👍");
     await woisMessage.react("👎");


### PR DESCRIPTION
Hab's mit der Firefox JS Console getestet. Sollte gehen.