### PR TITLE
Geschenk Embeds mit Feldern ausschmücken

### DIFF
--- a/src/service/lootDrop.ts
+++ b/src/service/lootDrop.ts
@@ -204,8 +204,22 @@ export async function postLootDrop(
                           url: "attachment://opened.gif",
                       }
                     : undefined,
+                fields: [
+                    {
+                        name: "🎉 Geschenköffner",
+                        value: winner.toString(),
+                    },
+                    ...(initialAttribute
+                        ? [
+                              {
+                                  name: "⭐ Rarität",
+                                  value: initialAttribute?.displayName,
+                              },
+                          ]
+                        : []),
+                ],
                 footer: {
-                    text: `🎉 ${winner.displayName} hat das Geschenk geöffnet\n${messages.join("\n")}`.trim(),
+                    text: `${messages.join("\n")}`.trim(),
                 },
             },
         ],

--- a/src/service/lootDrop.ts
+++ b/src/service/lootDrop.ts
@@ -21,6 +21,7 @@ import { randomEntry, randomEntryWeighted } from "@/utils/arrayUtils.js";
 
 import * as lootService from "@/service/loot.js";
 import {
+    LootAttributeClassId,
     LootAttributeKindId,
     lootAttributeTemplates,
     LootKindId,
@@ -157,12 +158,11 @@ export async function postLootDrop(
 
     const template = randomEntryWeighted(lootTemplates, weights);
 
-    const rarityWeights = lootAttributeTemplates.map(a => a.initialDropWeight ?? 0);
+    const rarities = lootAttributeTemplates.filter(a => a.classId === LootAttributeClassId.RARITY);
+    const rarityWeights = rarities.map(a => a.initialDropWeight ?? 0);
 
     const initialAttribute =
-        template.id === LootKindId.NICHTS
-            ? null
-            : randomEntryWeighted(lootAttributeTemplates, rarityWeights);
+        template.id === LootKindId.NICHTS ? null : randomEntryWeighted(rarities, rarityWeights);
 
     const claimedLoot = await lootService.createLoot(
         template,

--- a/src/service/lootDrop.ts
+++ b/src/service/lootDrop.ts
@@ -206,14 +206,16 @@ export async function postLootDrop(
                     : undefined,
                 fields: [
                     {
-                        name: "🎉 Geschenköffner",
+                        name: "🎉 Ehrenvoller Empfänger",
                         value: winner.toString(),
+                        inline: true,
                     },
                     ...(initialAttribute
                         ? [
                               {
-                                  name: "⭐ Rarität",
-                                  value: initialAttribute?.displayName,
+                                  name: "✨ Rarität",
+                                  value: `${initialAttribute.shortDisplay} ${initialAttribute.displayName}`.trim(),
+                                  inline: true,
                               },
                           ]
                         : []),

--- a/src/service/lootDrop.ts
+++ b/src/service/lootDrop.ts
@@ -219,7 +219,7 @@ export async function postLootDrop(
                         : []),
                 ],
                 footer: {
-                    text: `${messages.join("\n")}`.trim(),
+                    text: messages.join("\n").trim(),
                 },
             },
         ],

--- a/src/service/lootDrop.ts
+++ b/src/service/lootDrop.ts
@@ -197,7 +197,7 @@ export async function postLootDrop(
     await message.edit({
         embeds: [
             {
-                title: `Das Geschenk enthielt: ${template.titleText} ${initialAttribute?.shortDisplay ?? ""}`.trim(),
+                title: `Das Geschenk enthielt: ${template.titleText}`,
                 description: template.dropDescription,
                 image: attachment
                     ? {

--- a/src/service/lootDrop.ts
+++ b/src/service/lootDrop.ts
@@ -206,7 +206,7 @@ export async function postLootDrop(
                     : undefined,
                 fields: [
                     {
-                        name: "🎉 Ehrenvoller Empfänger",
+                        name: "🎉 Ehrenwerter Empfänger",
                         value: winner.toString(),
                         inline: true,
                     },


### PR DESCRIPTION
Macht für mich irgendwie mehr Sinn als den Footer zu nutzen. Außerdem wird so die Raritität auch sichtbarer.

Ich habe angenommen, dass nur Loot attribute mit class rarity für drops verwendet werden und das explizit gemacht.