### PR TITLE
Add Springer links to message delete handler

### DIFF
--- a/src/commands/springerWarning.ts
+++ b/src/commands/springerWarning.ts
@@ -328,7 +328,11 @@ export default class SpringerWarningCommand implements SpecialCommand {
     cooldownTime = 0;
 
     matches(message: Message<boolean>, _context: BotContext): boolean {
-        return this.#getWarning(message.content) !== undefined;
+        return SpringerWarningCommand.matchesPattern(message.content);
+    }
+
+    static matchesPattern(message: string): boolean {
+        return SpringerWarningCommand.#getWarningStatic(message) !== undefined;
     }
 
     async handleSpecialMessage(message: Message<true>, context: BotContext) {
@@ -343,6 +347,10 @@ export default class SpringerWarningCommand implements SpecialCommand {
     }
 
     #getWarning(value: string): string | undefined {
+        return SpringerWarningCommand.#getWarningStatic(value);
+    }
+
+    static #getWarningStatic(value: string): string | undefined {
         const message = value
             .toLowerCase()
             .replace("http://", "https://")

--- a/src/handler/messageDeleteHandler.ts
+++ b/src/handler/messageDeleteHandler.ts
@@ -5,6 +5,7 @@ import type { BotContext } from "#context.ts";
 import * as pollService from "#service/poll.ts";
 
 import InstagramLink from "#commands/instagram.ts";
+import SpringerWarningCommand from "#commands/springerWarning.ts";
 import TikTokLink from "#commands/tiktok.ts";
 
 import log from "#log";
@@ -49,8 +50,9 @@ export default async function (message: Message<true>, context: BotContext) {
 
     const isInstagramLink = InstagramLink.matchesPattern(message.content);
     const isTikTokLink = TikTokLink.matchesPattern(message.content);
+    const isSpringerLink = SpringerWarningCommand.matchesPattern(message.content);
 
-    if (isNormalCommand || isInstagramLink || isTikTokLink) {
+    if (isNormalCommand || isInstagramLink || isTikTokLink || isSpringerLink) {
         await deleteInlineRepliesFromBot(message, context.client.user);
     }
 }


### PR DESCRIPTION
Delete bot warning replies when users delete messages containing Axel Springer or Julian Reichelt links, matching the existing behavior for Instagram and TikTok links.