### PR TITLE
Implement automatic spam detection and banning feature

### DIFF
--- a/.github/config.json
+++ b/.github/config.json
@@ -74,6 +74,14 @@
             "sessionToken": "",
             "leaderBoardJsonUrl": "",
             "userMap": {}
+        },
+        "autoban": {
+            "enabled": true,
+            "deleteThreshold": 40,
+            "banThreshold": 60,
+            "banDurationHours": 24,
+            "timeWindowMinutes": 5,
+            "spamLogChannelId": "1513948506266538275"
         }
     },
 

--- a/.github/config.json
+++ b/.github/config.json
@@ -81,7 +81,7 @@
             "deleteThreshold": 40,
             "banThreshold": 60,
             "banDurationHours": 24,
-            "timeWindowMinutes": 5
+            "timeWindowDuration": "PT5M"
         }
     },
 

--- a/.github/config.json
+++ b/.github/config.json
@@ -77,11 +77,11 @@
         },
         "autoban": {
             "enabled": true,
+            "dryRun": true,
             "deleteThreshold": 40,
             "banThreshold": 60,
             "banDurationHours": 24,
-            "timeWindowMinutes": 5,
-            "spamLogChannelId": "1513948506266538275"
+            "timeWindowMinutes": 5
         }
     },
 
@@ -98,7 +98,8 @@
         "votesChannelId": "893179191556706384",
         "botSpamChannelId": "893179191556706387",
         "hauptwoisTextChannelId": "893179191825162371",
-        "roleAssignerChannelId": "893179190881452115"
+        "roleAssignerChannelId": "893179190881452115",
+        "spamLogChannelId": "1513948506266538275"
     },
 
     "voiceChannel": {

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -126,13 +126,13 @@ jobs:
           DISCORD_CLIENT_ID: ${{ secrets.CI_CLIENT_ID }}
           PR_ID: ${{ github.event.number }}
         run: |
-          envsubst < .github/config.json > config.json
+          envsubst < .github/config.json > config-ephemeral.json
 
       - name: Read config.json
         id: config
         uses: juliangruber/read-file-action@v1
         with:
-          path: ./config.json
+          path: ./config-ephemeral.json
 
       - name: Build args
         id: args

--- a/.infra/deploy-ephemeral.sh
+++ b/.infra/deploy-ephemeral.sh
@@ -19,13 +19,13 @@ mkdir -p "$TEMP_DIR/data"
 cp -r "$BOT_HOME_PATH/data" "$TEMP_DIR/data"
 cp -r "$BOT_HOME_PATH/.infra" "$TEMP_DIR/.infra"
 
-echo "$EPHEMERAL_BOT_CONFIG" > config.json
-echo "" >.env # Dummy env
+echo "$EPHEMERAL_BOT_CONFIG" > "$TEMP_DIR/config.json"
+echo "" > "$TEMP_DIR/.env" # Dummy env
 
 docker stop csz-bot-ephemeral || true
 docker rm csz-bot-ephemeral || true
-docker compose -p e2e -f .infra/compose.ephemeral.yaml pull bot
-docker compose -p e2e -f .infra/compose.ephemeral.yaml up \
+docker compose -p e2e -f "$TEMP_DIR/.infra/compose.ephemeral.yaml" pull bot
+docker compose -p e2e -f "$TEMP_DIR/.infra/compose.ephemeral.yaml" up \
     -d \
     --remove-orphans
 

--- a/.infra/deploy-ephemeral.sh
+++ b/.infra/deploy-ephemeral.sh
@@ -22,6 +22,8 @@ cp -r "$BOT_HOME_PATH/.infra" "$TEMP_DIR/.infra"
 echo "$EPHEMERAL_BOT_CONFIG" > "$TEMP_DIR/config.json"
 echo "" > "$TEMP_DIR/.env" # Dummy env
 
+chmod -R 777 "$TEMP_DIR/data"
+
 docker stop csz-bot-ephemeral || true
 docker rm csz-bot-ephemeral || true
 docker compose -p e2e -f "$TEMP_DIR/.infra/compose.ephemeral.yaml" pull bot

--- a/.infra/deploy-ephemeral.sh
+++ b/.infra/deploy-ephemeral.sh
@@ -31,4 +31,4 @@ docker compose -p e2e -f "$TEMP_DIR/.infra/compose.ephemeral.yaml" up \
     -d \
     --remove-orphans
 
-rm -rvf -- "$TEMP_DIR"
+# rm -rvf -- "$TEMP_DIR"

--- a/config.template.json
+++ b/config.template.json
@@ -90,10 +90,8 @@
             "banThreshold": 60,
             // Duration of the automatic ban in hours
             "banDurationHours": 24,
-            // Time window in minutes used to detect the same message across multiple channels
-            "timeWindowMinutes": 5,
-            // Channel ID of a mod-only channel for spam audit logs. Leave empty to disable.
-            "spamLogChannelId": ""
+            // ISO8601 duration used as the time window to detect the same message across multiple channels
+            "timeWindowDuration": "PT5M"
         }
     },
 
@@ -110,7 +108,9 @@
         "votesChannelId": "893179191556706384",
         "botSpamChannelId": "893179191556706387",
         "hauptwoisTextChannelId": "893179191825162371",
-        "roleAssignerChannelId": "893179190881452115"
+        "roleAssignerChannelId": "893179190881452115",
+        // Channel ID of a mod-only channel for spam audit logs. Leave empty to disable.
+        "spamLogChannelId": ""
     },
 
     "voiceChannel": {

--- a/config.template.json
+++ b/config.template.json
@@ -78,6 +78,18 @@
             "sessionToken": "",
             "leaderBoardJsonUrl": "",
             "userMap": {}
+        },
+        "autoban": {
+            // Set to true to enable automatic spam detection and banning
+            "enabled": false,
+            // Score at which a suspicious message is silently deleted (no ban)
+            "deleteThreshold": 40,
+            // Score at which the user is deleted + banned for banDurationHours
+            "banThreshold": 60,
+            // Duration of the automatic ban in hours
+            "banDurationHours": 24,
+            // Time window in minutes used to detect the same message across multiple channels
+            "timeWindowMinutes": 5
         }
     },
 

--- a/config.template.json
+++ b/config.template.json
@@ -82,6 +82,8 @@
         "autoban": {
             // Set to true to enable automatic spam detection and banning
             "enabled": false,
+            // Set to false to actually delete messages and ban users. While true, spam is only detected and logged.
+            "dryRun": true,
             // Score at which a suspicious message is silently deleted (no ban)
             "deleteThreshold": 40,
             // Score at which the user is deleted + banned for banDurationHours

--- a/config.template.json
+++ b/config.template.json
@@ -89,7 +89,9 @@
             // Duration of the automatic ban in hours
             "banDurationHours": 24,
             // Time window in minutes used to detect the same message across multiple channels
-            "timeWindowMinutes": 5
+            "timeWindowMinutes": 5,
+            // Channel ID of a mod-only channel for spam audit logs. Leave empty to disable.
+            "spamLogChannelId": ""
         }
     },
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -24,6 +24,7 @@ import {
 } from "#/handler/commandHandler.ts";
 import * as guildMemberHandler from "#/handler/guildMemberHandler.ts";
 import deleteThreadMessagesHandler from "#/handler/messageCreate/deleteThreadMessagesHandler.ts";
+import spamDetectionHandler from "#/handler/messageCreate/spamDetectionHandler.ts";
 import { handlePresenceUpdate } from "#/handler/presenceHandler.ts";
 import { createBotContext, type BotContext } from "#/context.ts";
 import { ehreReactionHandler } from "#/commands/ehre.ts";
@@ -151,6 +152,7 @@ login().then(
 
         log.info("Registering main event handlers...");
 
+        client.on("messageCreate", m => spamDetectionHandler(m, botContext));
         client.on("messageCreate", m => messageCommandHandler(m, botContext));
         client.on("messageCreate", m => deleteThreadMessagesHandler(m, botContext));
         client.on("guildMemberAdd", m => guildMemberHandler.added(botContext, m));

--- a/src/app.ts
+++ b/src/app.ts
@@ -136,17 +136,21 @@ login().then(
         client.user.setActivity(config.activity);
 
         try {
+            log.debug("Creating bot context...");
             botContext = await createBotContext(client);
 
+            log.debug("Bot context created, loading commands...");
             await loadCommands(botContext);
 
+            log.debug("Commands loaded, scheduling cron jobs...");
             await cronService.schedule(botContext);
 
             // When the application is ready, slash commands should be registered
+            log.debug("Registering application commands as guild commands...");
             await registerAllApplicationCommandsAsGuildCommands(botContext);
         } catch (err) {
-            sentry.captureException(err);
             log.error(err, "Error in `ready` handler");
+            sentry.captureException(err);
             process.exit(1);
         }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -90,6 +90,7 @@ export interface BotContext {
             banThreshold: number;
             banDurationHours: number;
             timeWindowMinutes: number;
+            spamLog: TextChannel | null;
         };
     };
 
@@ -332,6 +333,9 @@ export async function createBotContext(client: Client<true>): Promise<BotContext
                 banThreshold: config.command.autoban?.banThreshold ?? 60,
                 banDurationHours: config.command.autoban?.banDurationHours ?? 24,
                 timeWindowMinutes: config.command.autoban?.timeWindowMinutes ?? 5,
+                spamLog: config.command.autoban?.spamLogChannelId
+                    ? ensureTextChannel(guild, config.command.autoban.spamLogChannelId)
+                    : null,
             },
         },
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -84,6 +84,13 @@ export interface BotContext {
             leaderBoardJsonUrl: string;
             userMap: Record<Snowflake, UserMapEntry>;
         };
+        autoban: {
+            enabled: boolean;
+            deleteThreshold: number;
+            banThreshold: number;
+            banDurationHours: number;
+            timeWindowMinutes: number;
+        };
     };
 
     roles: {
@@ -318,6 +325,13 @@ export async function createBotContext(client: Client<true>): Promise<BotContext
                 sessionToken: config.command.aoc.sessionToken,
                 leaderBoardJsonUrl: config.command.aoc.leaderBoardJsonUrl,
                 userMap: config.command.aoc.userMap,
+            },
+            autoban: {
+                enabled: config.command.autoban?.enabled ?? false,
+                deleteThreshold: config.command.autoban?.deleteThreshold ?? 40,
+                banThreshold: config.command.autoban?.banThreshold ?? 60,
+                banDurationHours: config.command.autoban?.banDurationHours ?? 24,
+                timeWindowMinutes: config.command.autoban?.timeWindowMinutes ?? 5,
             },
         },
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -90,8 +90,7 @@ export interface BotContext {
             deleteThreshold: number;
             banThreshold: number;
             banDurationHours: number;
-            timeWindowMinutes: number;
-            spamLog: TextChannel | null;
+            timeWindowDuration: Temporal.Duration;
         };
     };
 
@@ -129,6 +128,7 @@ export interface BotContext {
         botSpam: TextChannel;
         hauptwoisText: TextChannel;
         roleAssigner: TextChannel;
+        spamLog: TextChannel | null;
     };
 
     voiceChannels: {
@@ -334,10 +334,9 @@ export async function createBotContext(client: Client<true>): Promise<BotContext
                 deleteThreshold: config.command.autoban?.deleteThreshold ?? 40,
                 banThreshold: config.command.autoban?.banThreshold ?? 60,
                 banDurationHours: config.command.autoban?.banDurationHours ?? 24,
-                timeWindowMinutes: config.command.autoban?.timeWindowMinutes ?? 5,
-                spamLog: config.command.autoban?.spamLogChannelId
-                    ? ensureTextChannel(guild, config.command.autoban.spamLogChannelId)
-                    : null,
+                timeWindowDuration: Temporal.Duration.from(
+                    config.command.autoban?.timeWindowDuration ?? "PT5M",
+                ),
             },
         },
 
@@ -371,6 +370,9 @@ export async function createBotContext(client: Client<true>): Promise<BotContext
             botSpam: ensureTextChannel(guild, textChannel.botSpamChannelId),
             hauptwoisText: ensureTextChannel(guild, textChannel.hauptwoisTextChannelId),
             roleAssigner: ensureTextChannel(guild, textChannel.roleAssignerChannelId),
+            spamLog: textChannel.spamLogChannelId
+                ? ensureTextChannel(guild, textChannel.spamLogChannelId)
+                : null,
         },
 
         voiceChannels: {

--- a/src/context.ts
+++ b/src/context.ts
@@ -86,6 +86,7 @@ export interface BotContext {
         };
         autoban: {
             enabled: boolean;
+            dryRun: boolean;
             deleteThreshold: number;
             banThreshold: number;
             banDurationHours: number;
@@ -329,6 +330,7 @@ export async function createBotContext(client: Client<true>): Promise<BotContext
             },
             autoban: {
                 enabled: config.command.autoban?.enabled ?? false,
+                dryRun: config.command.autoban?.dryRun ?? true,
                 deleteThreshold: config.command.autoban?.deleteThreshold ?? 40,
                 banThreshold: config.command.autoban?.banThreshold ?? 60,
                 banDurationHours: config.command.autoban?.banDurationHours ?? 24,

--- a/src/context.ts
+++ b/src/context.ts
@@ -18,6 +18,7 @@ import { SpotifyApi } from "@spotify/web-api-ts-sdk";
 
 import type { UserMapEntry } from "#/commands/aoc.ts";
 import { readConfig } from "#/service/config.ts";
+import log from "#log";
 
 /**
  * Object that's passed to every executed command to make it easier to access common channels without repeatedly retrieving stuff via IDs.
@@ -237,8 +238,10 @@ function ensureEmoji(guild: Guild, emojiId: Snowflake, fallbackName: string): Gu
 // #endregion
 
 export async function createBotContext(client: Client<true>): Promise<BotContext> {
+    log.debug("createBotContext: reading config...");
     const config = await readConfig();
 
+    log.debug("createBotContext: config read, resolving guild...");
     const guild = client.guilds.cache.get(config.guildGuildId);
     if (!guild) {
         throw new Error(`Cannot find configured guild "${config.guildGuildId}"`);
@@ -249,7 +252,9 @@ export async function createBotContext(client: Client<true>): Promise<BotContext
     const voiceChannel = config.voiceChannel;
 
     const soundsPath = path.resolve("data/sounds");
+    log.debug({ soundsPath }, "createBotContext: creating sounds directory...");
     await fs.mkdir(soundsPath, { recursive: true });
+    log.debug("createBotContext: sounds directory ready, building context object...");
 
     return {
         client,

--- a/src/handler/messageCreate/spamDetectionHandler.ts
+++ b/src/handler/messageCreate/spamDetectionHandler.ts
@@ -104,7 +104,7 @@ export default async function spamDetectionHandler(
             spamDetection.trackMessage(member.id, message.id, message.channelId, message.content);
         }
 
-        autoban.spamLog
+        context.textChannels.spamLog
             ?.send({
                 embeds: [
                     buildSpamLogEmbed(
@@ -160,7 +160,7 @@ export default async function spamDetectionHandler(
             spamDetection.trackMessage(member.id, message.id, message.channelId, message.content);
         }
 
-        autoban.spamLog
+        context.textChannels.spamLog
             ?.send({
                 embeds: [
                     buildSpamLogEmbed(

--- a/src/handler/messageCreate/spamDetectionHandler.ts
+++ b/src/handler/messageCreate/spamDetectionHandler.ts
@@ -26,7 +26,7 @@ function buildSpamLogEmbed(
             { name: "Score", value: `${score} / ${threshold}`, inline: true },
             {
                 name: "Erkannte Merkmale",
-                value: triggeredLabels.map(l => `• ${l}`).join("\n") || "—",
+                value: triggeredLabels.map(l => `- ${l}`).join("\n") || "—",
                 inline: false,
             },
             {
@@ -105,7 +105,7 @@ export default async function spamDetectionHandler(
 
         const reason = [
             "Automatischer Bann: Spam-Erkennung",
-            ...triggeredLabels.map(l => `• ${l}`),
+            ...triggeredLabels.map(l => `- ${l}`),
         ].join("\n");
 
         const err = await banService.banUser(

--- a/src/handler/messageCreate/spamDetectionHandler.ts
+++ b/src/handler/messageCreate/spamDetectionHandler.ts
@@ -1,10 +1,44 @@
-import type { Message } from "discord.js";
+import type { APIEmbed, GuildMember, Message } from "discord.js";
 import * as sentry from "@sentry/node";
 
 import type { BotContext } from "#/context.ts";
 import * as banService from "#/service/ban.ts";
 import * as spamDetection from "#/service/spamDetection.ts";
 import log from "#log";
+
+type SpamAction = "ban" | "delete";
+
+function buildSpamLogEmbed(
+    action: SpamAction,
+    message: Message<true>,
+    member: GuildMember,
+    score: number,
+    threshold: number,
+    triggeredLabels: readonly string[],
+): APIEmbed {
+    const isBan = action === "ban";
+    return {
+        color: isBan ? 0xe74c3c : 0xe67e22,
+        title: isBan ? "🚫 Autoban: Gebannt" : "⚠️ Autoban: Nachricht gelöscht",
+        fields: [
+            { name: "Nutzer", value: `${member} (${member.id})`, inline: true },
+            { name: "Kanal", value: `${message.channel}`, inline: true },
+            { name: "Score", value: `${score} / ${threshold}`, inline: true },
+            {
+                name: "Erkannte Merkmale",
+                value: triggeredLabels.map(l => `• ${l}`).join("\n") || "—",
+                inline: false,
+            },
+            {
+                name: "Nachricht",
+                value: message.content.slice(0, 1024) || "*(leer)*",
+                inline: false,
+            },
+        ],
+        timestamp: new Date().toISOString(),
+        footer: { text: `User-ID: ${member.id}` },
+    };
+}
 
 export default async function spamDetectionHandler(
     message: Message,
@@ -54,6 +88,21 @@ export default async function spamDetectionHandler(
 
         await message.delete().catch(() => undefined);
 
+        autoban.spamLog
+            ?.send({
+                embeds: [
+                    buildSpamLogEmbed(
+                        "ban",
+                        message,
+                        member,
+                        score,
+                        autoban.banThreshold,
+                        triggeredLabels,
+                    ),
+                ],
+            })
+            .catch(err => log.warn(err, "Failed to post spam log embed"));
+
         const reason = [
             "Automatischer Bann: Spam-Erkennung",
             ...triggeredLabels.map(l => `• ${l}`),
@@ -79,6 +128,22 @@ export default async function spamDetectionHandler(
     if (score >= autoban.deleteThreshold) {
         log.info({ userId: member.id, score }, "Auto-delete: suspicious message removed");
         await message.delete().catch(() => undefined);
+
+        autoban.spamLog
+            ?.send({
+                embeds: [
+                    buildSpamLogEmbed(
+                        "delete",
+                        message,
+                        member,
+                        score,
+                        autoban.deleteThreshold,
+                        triggeredLabels,
+                    ),
+                ],
+            })
+            .catch(err => log.warn(err, "Failed to post spam log embed"));
+
         return;
     }
 

--- a/src/handler/messageCreate/spamDetectionHandler.ts
+++ b/src/handler/messageCreate/spamDetectionHandler.ts
@@ -15,11 +15,16 @@ function buildSpamLogEmbed(
     score: number,
     threshold: number,
     triggeredLabels: readonly string[],
+    dryRun: boolean,
 ): APIEmbed {
     const isBan = action === "ban";
+    const dryRunPrefix = dryRun ? "🧪 [Testmodus] " : "";
+    const title = isBan
+        ? `${dryRunPrefix}🚫 Autoban: ${dryRun ? "Würde gebannt werden" : "Gebannt"}`
+        : `${dryRunPrefix}⚠️ Autoban: ${dryRun ? "Nachricht würde gelöscht werden" : "Nachricht gelöscht"}`;
     return {
         color: isBan ? 0xe74c3c : 0xe67e22,
-        title: isBan ? "🚫 Autoban: Gebannt" : "⚠️ Autoban: Nachricht gelöscht",
+        title,
         fields: [
             { name: "Nutzer", value: `${member} (${member.id})`, inline: true },
             { name: "Kanal", value: `${message.channel}`, inline: true },
@@ -68,25 +73,36 @@ export default async function spamDetectionHandler(
     const { autoban } = context.commandConfig;
     const { score, triggeredLabels } = spamDetection.evaluateMessage(message, member, context);
 
+    const { dryRun } = autoban;
+
     if (score >= autoban.banThreshold) {
-        log.info({ userId: member.id, score, triggeredLabels }, "Auto-ban: spam threshold crossed");
+        log.info(
+            { userId: member.id, score, triggeredLabels },
+            dryRun
+                ? "Auto-ban (dry run): spam threshold crossed"
+                : "Auto-ban: spam threshold crossed",
+        );
 
         // Delete previously tracked messages from this user across channels
         const tracked = spamDetection.getTrackedMessages(member.id);
         spamDetection.flushUser(member.id);
 
-        for (const { messageId, channelId } of tracked) {
-            const channel = context.guild.channels.cache.get(channelId);
-            if (!channel?.isTextBased()) {
-                continue;
+        if (!dryRun) {
+            for (const { messageId, channelId } of tracked) {
+                const channel = context.guild.channels.cache.get(channelId);
+                if (!channel?.isTextBased()) {
+                    continue;
+                }
+                const msg = await channel.messages.fetch(messageId).catch(() => null);
+                if (msg) {
+                    await msg.delete().catch(() => undefined);
+                }
             }
-            const msg = await channel.messages.fetch(messageId).catch(() => null);
-            if (msg) {
-                await msg.delete().catch(() => undefined);
-            }
-        }
 
-        await message.delete().catch(() => undefined);
+            await message.delete().catch(() => undefined);
+        } else {
+            spamDetection.trackMessage(member.id, message.id, message.channelId, message.content);
+        }
 
         autoban.spamLog
             ?.send({
@@ -98,10 +114,15 @@ export default async function spamDetectionHandler(
                         score,
                         autoban.banThreshold,
                         triggeredLabels,
+                        dryRun,
                     ),
                 ],
             })
             .catch(err => log.warn(err, "Failed to post spam log embed"));
+
+        if (dryRun) {
+            return;
+        }
 
         const reason = [
             "Automatischer Bann: Spam-Erkennung",
@@ -126,8 +147,18 @@ export default async function spamDetectionHandler(
     }
 
     if (score >= autoban.deleteThreshold) {
-        log.info({ userId: member.id, score }, "Auto-delete: suspicious message removed");
-        await message.delete().catch(() => undefined);
+        log.info(
+            { userId: member.id, score },
+            dryRun
+                ? "Auto-delete (dry run): suspicious message detected"
+                : "Auto-delete: suspicious message removed",
+        );
+
+        if (!dryRun) {
+            await message.delete().catch(() => undefined);
+        } else {
+            spamDetection.trackMessage(member.id, message.id, message.channelId, message.content);
+        }
 
         autoban.spamLog
             ?.send({
@@ -139,6 +170,7 @@ export default async function spamDetectionHandler(
                         score,
                         autoban.deleteThreshold,
                         triggeredLabels,
+                        dryRun,
                     ),
                 ],
             })

--- a/src/handler/messageCreate/spamDetectionHandler.ts
+++ b/src/handler/messageCreate/spamDetectionHandler.ts
@@ -67,6 +67,7 @@ export default async function spamDetectionHandler(
         context.roleGuard.isTrusted(member) ||
         context.roleGuard.isGruendervater(member)
     ) {
+        log.debug({ userId: member.id }, "spamDetectionHandler: skipping guarded member");
         return;
     }
 
@@ -74,6 +75,17 @@ export default async function spamDetectionHandler(
     const { score, triggeredLabels } = spamDetection.evaluateMessage(message, member, context);
 
     const { dryRun } = autoban;
+
+    log.debug(
+        {
+            userId: member.id,
+            score,
+            deleteThreshold: autoban.deleteThreshold,
+            banThreshold: autoban.banThreshold,
+            dryRun,
+        },
+        "spamDetectionHandler: message evaluated",
+    );
 
     if (score >= autoban.banThreshold) {
         log.info(
@@ -88,14 +100,28 @@ export default async function spamDetectionHandler(
         spamDetection.flushUser(member.id);
 
         if (!dryRun) {
+            log.debug(
+                { userId: member.id, trackedCount: tracked.length },
+                "spamDetectionHandler: deleting tracked cross-channel messages",
+            );
+
             for (const { messageId, channelId } of tracked) {
                 const channel = context.guild.channels.cache.get(channelId);
                 if (!channel?.isTextBased()) {
+                    log.debug(
+                        { userId: member.id, messageId, channelId },
+                        "spamDetectionHandler: channel not found or not text-based, skipping",
+                    );
                     continue;
                 }
                 const msg = await channel.messages.fetch(messageId).catch(() => null);
                 if (msg) {
                     await msg.delete().catch(() => undefined);
+                } else {
+                    log.debug(
+                        { userId: member.id, messageId, channelId },
+                        "spamDetectionHandler: tracked message not found, skipping",
+                    );
                 }
             }
 
@@ -179,5 +205,9 @@ export default async function spamDetectionHandler(
         return;
     }
 
+    log.debug(
+        { userId: member.id, score },
+        "spamDetectionHandler: message below thresholds, tracking",
+    );
     spamDetection.trackMessage(member.id, message.id, message.channelId, message.content);
 }

--- a/src/handler/messageCreate/spamDetectionHandler.ts
+++ b/src/handler/messageCreate/spamDetectionHandler.ts
@@ -32,10 +32,10 @@ export default async function spamDetectionHandler(
     }
 
     const { autoban } = context.commandConfig;
-    const score = spamDetection.evaluateMessage(message, member, context);
+    const { score, triggeredLabels } = spamDetection.evaluateMessage(message, member, context);
 
     if (score >= autoban.banThreshold) {
-        log.info({ userId: member.id, score }, "Auto-ban: spam threshold crossed");
+        log.info({ userId: member.id, score, triggeredLabels }, "Auto-ban: spam threshold crossed");
 
         // Delete previously tracked messages from this user across channels
         const tracked = spamDetection.getTrackedMessages(member.id);
@@ -54,11 +54,16 @@ export default async function spamDetectionHandler(
 
         await message.delete().catch(() => undefined);
 
+        const reason = [
+            "Automatischer Bann: Spam-Erkennung",
+            ...triggeredLabels.map(l => `• ${l}`),
+        ].join("\n");
+
         const err = await banService.banUser(
             context,
             member,
             context.client.user,
-            `Automatischer Bann: Spam erkannt (Score: ${score})`,
+            reason,
             false,
             autoban.banDurationHours,
         );

--- a/src/handler/messageCreate/spamDetectionHandler.ts
+++ b/src/handler/messageCreate/spamDetectionHandler.ts
@@ -1,0 +1,81 @@
+import type { Message } from "discord.js";
+import * as sentry from "@sentry/node";
+
+import type { BotContext } from "#/context.ts";
+import * as banService from "#/service/ban.ts";
+import * as spamDetection from "#/service/spamDetection.ts";
+import log from "#log";
+
+export default async function spamDetectionHandler(
+    message: Message,
+    context: BotContext,
+): Promise<void> {
+    if (!context.commandConfig.autoban.enabled) {
+        return;
+    }
+
+    if (message.author.bot || !message.inGuild()) {
+        return;
+    }
+
+    const { member } = message;
+    if (!member) {
+        return;
+    }
+
+    if (
+        context.roleGuard.isMod(member) ||
+        context.roleGuard.isTrusted(member) ||
+        context.roleGuard.isGruendervater(member)
+    ) {
+        return;
+    }
+
+    const { autoban } = context.commandConfig;
+    const score = spamDetection.evaluateMessage(message, member, context);
+
+    if (score >= autoban.banThreshold) {
+        log.info({ userId: member.id, score }, "Auto-ban: spam threshold crossed");
+
+        // Delete previously tracked messages from this user across channels
+        const tracked = spamDetection.getTrackedMessages(member.id);
+        spamDetection.flushUser(member.id);
+
+        for (const { messageId, channelId } of tracked) {
+            const channel = context.guild.channels.cache.get(channelId);
+            if (!channel?.isTextBased()) {
+                continue;
+            }
+            const msg = await channel.messages.fetch(messageId).catch(() => null);
+            if (msg) {
+                await msg.delete().catch(() => undefined);
+            }
+        }
+
+        await message.delete().catch(() => undefined);
+
+        const err = await banService.banUser(
+            context,
+            member,
+            context.client.user,
+            `Automatischer Bann: Spam erkannt (Score: ${score})`,
+            false,
+            autoban.banDurationHours,
+        );
+
+        if (err) {
+            sentry.captureException(new Error(err));
+            log.error({ userId: member.id, err }, "Auto-ban failed after spam detection");
+        }
+
+        return;
+    }
+
+    if (score >= autoban.deleteThreshold) {
+        log.info({ userId: member.id, score }, "Auto-delete: suspicious message removed");
+        await message.delete().catch(() => undefined);
+        return;
+    }
+
+    spamDetection.trackMessage(member.id, message.id, message.channelId, message.content);
+}

--- a/src/service/config.ts
+++ b/src/service/config.ts
@@ -152,9 +152,8 @@ export interface Config {
             deleteThreshold: number;
             banThreshold: number;
             banDurationHours: number;
-            timeWindowMinutes: number;
-            /** Channel ID for the mod-only spam audit log. Leave empty to disable. */
-            spamLogChannelId?: Snowflake;
+            /** ISO8601 duration string, e.g. "PT5M" for 5 minutes. */
+            timeWindowDuration: string;
         };
     };
 
@@ -172,6 +171,8 @@ export interface Config {
         botSpamChannelId: Snowflake;
         hauptwoisTextChannelId: Snowflake;
         roleAssignerChannelId: Snowflake;
+        /** Channel ID for the mod-only spam audit log. Leave empty to disable. */
+        spamLogChannelId?: Snowflake;
     };
 
     voiceChannel: {

--- a/src/service/config.ts
+++ b/src/service/config.ts
@@ -151,6 +151,8 @@ export interface Config {
             banThreshold: number;
             banDurationHours: number;
             timeWindowMinutes: number;
+            /** Channel ID for the mod-only spam audit log. Leave empty to disable. */
+            spamLogChannelId?: Snowflake;
         };
     };
 

--- a/src/service/config.ts
+++ b/src/service/config.ts
@@ -145,6 +145,13 @@ export interface Config {
                 }
             >;
         };
+        autoban?: {
+            enabled: boolean;
+            deleteThreshold: number;
+            banThreshold: number;
+            banDurationHours: number;
+            timeWindowMinutes: number;
+        };
     };
 
     deleteThreadMessagesInChannelIds: readonly Snowflake[];

--- a/src/service/config.ts
+++ b/src/service/config.ts
@@ -147,6 +147,8 @@ export interface Config {
         };
         autoban?: {
             enabled: boolean;
+            /** When true, spam is detected and logged but no message is deleted and no user is banned. */
+            dryRun?: boolean;
             deleteThreshold: number;
             banThreshold: number;
             banDurationHours: number;

--- a/src/service/spamDetection.ts
+++ b/src/service/spamDetection.ts
@@ -1,6 +1,7 @@
 import type { GuildMember, Message, Snowflake } from "discord.js";
 
 import type { BotContext } from "#/context.ts";
+import log from "#log";
 
 type RecentMessage = {
     messageId: Snowflake;
@@ -172,6 +173,11 @@ export function evaluateMessage(
         recentMessages.set(member.id, history);
     }
 
+    log.debug(
+        { userId: member.id, historySize: history.length },
+        "spamDetection: evaluating message",
+    );
+
     const results = signals.map(({ label, category, evaluate }) => ({
         label,
         category,
@@ -184,9 +190,22 @@ export function evaluateMessage(
     const contentScore = results
         .filter(r => r.category === "content")
         .reduce((sum, r) => sum + r.points, 0);
+    const cappedIdentityScore = Math.min(identityScore, IDENTITY_SCORE_CAP);
+
+    log.debug(
+        {
+            userId: member.id,
+            identityScore,
+            cappedIdentityScore,
+            contentScore,
+            score: cappedIdentityScore + contentScore,
+            triggered: results.filter(r => r.points > 0).map(r => `${r.label} (+${r.points})`),
+        },
+        "spamDetection: evaluation result",
+    );
 
     return {
-        score: Math.min(identityScore, IDENTITY_SCORE_CAP) + contentScore,
+        score: cappedIdentityScore + contentScore,
         triggeredLabels: results.filter(r => r.points > 0).map(r => r.label),
     };
 }
@@ -205,6 +224,11 @@ export function trackMessage(
         recordedAt: Temporal.Now.instant(),
     });
     recentMessages.set(userId, existing);
+
+    log.debug(
+        { userId, messageId, channelId, trackedCount: existing.length },
+        "spamDetection: tracked message",
+    );
 }
 
 export function getTrackedMessages(userId: Snowflake): readonly RecentMessage[] {
@@ -212,5 +236,8 @@ export function getTrackedMessages(userId: Snowflake): readonly RecentMessage[] 
 }
 
 export function flushUser(userId: Snowflake): void {
-    recentMessages.delete(userId);
+    const hadHistory = recentMessages.delete(userId);
+    if (hadHistory) {
+        log.debug({ userId }, "spamDetection: flushed tracked history for user");
+    }
 }

--- a/src/service/spamDetection.ts
+++ b/src/service/spamDetection.ts
@@ -1,0 +1,154 @@
+import type { GuildMember, Message, Snowflake } from "discord.js";
+
+import type { BotContext } from "#/context.ts";
+
+type RecentMessage = {
+    messageId: Snowflake;
+    content: string;
+    channelId: Snowflake;
+    recordedAt: Temporal.Instant;
+};
+
+type Signal = (
+    message: Message<true>,
+    member: GuildMember,
+    context: BotContext, // available if a future signal needs it
+    history: readonly RecentMessage[],
+) => number;
+
+const recentMessages = new Map<Snowflake, RecentMessage[]>();
+
+const URL_PATTERN = /https?:\/\//i;
+const DISCORD_INVITE_PATTERN = /discord\.gg\//i;
+const TRAILING_DIGITS_PATTERN = /\d{2,}$/;
+
+const SCORES = {
+    accountAgeUnder7Days: 30,
+    accountAgeUnder30Days: 15,
+    guildJoinUnder10Minutes: 40,
+    guildJoinUnder1Hour: 25,
+    guildJoinUnder24Hours: 10,
+    trailingDigitsInUsername: 10,
+    containsUrl: 20,
+    containsDiscordInvite: 25,
+    massUserMentions: 20,
+    roleMentions: 25,
+    crossChannelDuplicate: 30,
+    onlyDefaultRole: 10,
+} as const;
+
+function scoreAccountAge(_msg: Message<true>, member: GuildMember): number {
+    const now = Temporal.Now.instant();
+    const created = Temporal.Instant.fromEpochMilliseconds(member.user.createdTimestamp);
+    if (Temporal.Instant.compare(created, now.subtract({ hours: 7 * 24 })) > 0) {
+        return SCORES.accountAgeUnder7Days;
+    }
+    if (Temporal.Instant.compare(created, now.subtract({ hours: 30 * 24 })) > 0) {
+        return SCORES.accountAgeUnder30Days;
+    }
+    return 0;
+}
+
+function scoreGuildJoin(_msg: Message<true>, member: GuildMember): number {
+    if (member.joinedTimestamp === null) return 0;
+    const now = Temporal.Now.instant();
+    const joined = Temporal.Instant.fromEpochMilliseconds(member.joinedTimestamp);
+    if (Temporal.Instant.compare(joined, now.subtract({ minutes: 10 })) > 0) {
+        return SCORES.guildJoinUnder10Minutes;
+    }
+    if (Temporal.Instant.compare(joined, now.subtract({ hours: 1 })) > 0) {
+        return SCORES.guildJoinUnder1Hour;
+    }
+    if (Temporal.Instant.compare(joined, now.subtract({ hours: 24 })) > 0) {
+        return SCORES.guildJoinUnder24Hours;
+    }
+    return 0;
+}
+
+function scoreTrailingDigits(_msg: Message<true>, member: GuildMember): number {
+    return TRAILING_DIGITS_PATTERN.test(member.user.username) ? SCORES.trailingDigitsInUsername : 0;
+}
+
+function scoreUrl(msg: Message<true>): number {
+    return URL_PATTERN.test(msg.content) ? SCORES.containsUrl : 0;
+}
+
+function scoreDiscordInvite(msg: Message<true>): number {
+    return DISCORD_INVITE_PATTERN.test(msg.content) ? SCORES.containsDiscordInvite : 0;
+}
+
+function scoreMassUserMentions(msg: Message<true>): number {
+    return msg.mentions.users.size >= 2 ? SCORES.massUserMentions : 0;
+}
+
+function scoreRoleMentions(msg: Message<true>): number {
+    return msg.mentions.roles.size > 0 ? SCORES.roleMentions : 0;
+}
+
+function scoreOnlyDefaultRole(_msg: Message<true>, member: GuildMember): number {
+    // ≤ 2 means only @everyone + the default role, i.e. no self-assigned roles
+    return member.roles.cache.size <= 2 ? SCORES.onlyDefaultRole : 0;
+}
+
+function scoreCrossChannelDuplicate(
+    msg: Message<true>,
+    _member: GuildMember,
+    _context: BotContext,
+    history: readonly RecentMessage[],
+): number {
+    const normalized = msg.content.trim().toLowerCase();
+    return history.some(m => m.content === normalized && m.channelId !== msg.channelId)
+        ? SCORES.crossChannelDuplicate
+        : 0;
+}
+
+const signals: readonly Signal[] = [
+    scoreAccountAge,
+    scoreGuildJoin,
+    scoreTrailingDigits,
+    scoreUrl,
+    scoreDiscordInvite,
+    scoreMassUserMentions,
+    scoreRoleMentions,
+    scoreOnlyDefaultRole,
+    scoreCrossChannelDuplicate,
+];
+
+export function evaluateMessage(
+    message: Message<true>,
+    member: GuildMember,
+    context: BotContext,
+): number {
+    const { timeWindowMinutes } = context.commandConfig.autoban;
+    const now = Temporal.Now.instant();
+    const windowStart = now.subtract({ minutes: timeWindowMinutes });
+    const history = (recentMessages.get(member.id) ?? []).filter(
+        m => Temporal.Instant.compare(m.recordedAt, windowStart) > 0,
+    );
+
+    return signals.reduce((total, signal) => total + signal(message, member, context, history), 0);
+}
+
+export function trackMessage(
+    userId: Snowflake,
+    messageId: Snowflake,
+    channelId: Snowflake,
+    content: string,
+): void {
+    const existing = recentMessages.get(userId) ?? [];
+    existing.push({
+        messageId,
+        content: content.trim().toLowerCase(),
+        channelId,
+        recordedAt: Temporal.Now.instant(),
+    });
+    recentMessages.set(userId, existing);
+}
+
+export function getTrackedMessages(userId: Snowflake): readonly RecentMessage[] {
+    return recentMessages.get(userId) ?? [];
+}
+
+export function flushUser(userId: Snowflake): void {
+    recentMessages.delete(userId);
+}

--- a/src/service/spamDetection.ts
+++ b/src/service/spamDetection.ts
@@ -20,7 +20,6 @@ const recentMessages = new Map<Snowflake, RecentMessage[]>();
 
 const URL_PATTERN = /https?:\/\//i;
 const DISCORD_INVITE_PATTERN = /discord\.gg\//i;
-const TRAILING_DIGITS_PATTERN = /\d{2,}$/;
 
 const SCORES = {
     accountAgeUnder7Days: 30,
@@ -28,7 +27,6 @@ const SCORES = {
     guildJoinUnder10Minutes: 40,
     guildJoinUnder1Hour: 25,
     guildJoinUnder24Hours: 10,
-    trailingDigitsInUsername: 10,
     containsUrl: 20,
     containsDiscordInvite: 25,
     massUserMentions: 20,
@@ -63,10 +61,6 @@ function scoreGuildJoin(_msg: Message<true>, member: GuildMember): number {
         return SCORES.guildJoinUnder24Hours;
     }
     return 0;
-}
-
-function scoreTrailingDigits(_msg: Message<true>, member: GuildMember): number {
-    return TRAILING_DIGITS_PATTERN.test(member.user.username) ? SCORES.trailingDigitsInUsername : 0;
 }
 
 function scoreUrl(msg: Message<true>): number {
@@ -105,7 +99,6 @@ function scoreCrossChannelDuplicate(
 const signals: readonly Signal[] = [
     scoreAccountAge,
     scoreGuildJoin,
-    scoreTrailingDigits,
     scoreUrl,
     scoreDiscordInvite,
     scoreMassUserMentions,

--- a/src/service/spamDetection.ts
+++ b/src/service/spamDetection.ts
@@ -140,6 +140,12 @@ export function evaluateMessage(
         m => Temporal.Instant.compare(m.recordedAt, windowStart) > 0,
     );
 
+    if (history.length === 0) {
+        recentMessages.delete(member.id);
+    } else {
+        recentMessages.set(member.id, history);
+    }
+
     const results = signals.map(({ label, evaluate }) => ({
         label,
         points: evaluate(message, member, context, history),

--- a/src/service/spamDetection.ts
+++ b/src/service/spamDetection.ts
@@ -9,12 +9,22 @@ type RecentMessage = {
     recordedAt: Temporal.Instant;
 };
 
-type Signal = (
+type SignalEvaluate = (
     message: Message<true>,
     member: GuildMember,
     context: BotContext, // available if a future signal needs it
     history: readonly RecentMessage[],
 ) => number;
+
+type SignalDef = {
+    label: string;
+    evaluate: SignalEvaluate;
+};
+
+export type EvaluationResult = {
+    score: number;
+    triggeredLabels: readonly string[];
+};
 
 const recentMessages = new Map<Snowflake, RecentMessage[]>();
 
@@ -35,91 +45,110 @@ const SCORES = {
     onlyDefaultRole: 10,
 } as const;
 
-function scoreAccountAge(_msg: Message<true>, member: GuildMember): number {
-    const now = Temporal.Now.instant();
-    const created = Temporal.Instant.fromEpochMilliseconds(member.user.createdTimestamp);
-    if (Temporal.Instant.compare(created, now.subtract({ hours: 7 * 24 })) > 0) {
-        return SCORES.accountAgeUnder7Days;
-    }
-    if (Temporal.Instant.compare(created, now.subtract({ hours: 30 * 24 })) > 0) {
-        return SCORES.accountAgeUnder30Days;
-    }
-    return 0;
+/** Returns true if `instant` occurred more recently than `duration` ago. */
+function isWithin(instant: Temporal.Instant, duration: Temporal.DurationLike): boolean {
+    return Temporal.Instant.compare(instant, Temporal.Now.instant().subtract(duration)) > 0;
 }
 
-function scoreGuildJoin(_msg: Message<true>, member: GuildMember): number {
-    if (member.joinedTimestamp === null) return 0;
-    const now = Temporal.Now.instant();
-    const joined = Temporal.Instant.fromEpochMilliseconds(member.joinedTimestamp);
-    if (Temporal.Instant.compare(joined, now.subtract({ minutes: 10 })) > 0) {
-        return SCORES.guildJoinUnder10Minutes;
-    }
-    if (Temporal.Instant.compare(joined, now.subtract({ hours: 1 })) > 0) {
-        return SCORES.guildJoinUnder1Hour;
-    }
-    if (Temporal.Instant.compare(joined, now.subtract({ hours: 48 })) > 0) {
-        return SCORES.guildJoinUnder48Hours;
-    }
-    return 0;
-}
-
-function scoreUrl(msg: Message<true>): number {
-    return URL_PATTERN.test(msg.content) ? SCORES.containsUrl : 0;
-}
-
-function scoreDiscordInvite(msg: Message<true>): number {
-    return DISCORD_INVITE_PATTERN.test(msg.content) ? SCORES.containsDiscordInvite : 0;
-}
-
-function scoreMassUserMentions(msg: Message<true>): number {
-    return msg.mentions.users.size >= 2 ? SCORES.massUserMentions : 0;
-}
-
-function scoreRoleMentions(msg: Message<true>): number {
-    return msg.mentions.roles.size > 0 ? SCORES.roleMentions : 0;
-}
-
-function scoreOnlyDefaultRole(_msg: Message<true>, member: GuildMember): number {
-    // ≤ 2 means only @everyone + the default role, i.e. no self-assigned roles
-    return member.roles.cache.size <= 2 ? SCORES.onlyDefaultRole : 0;
-}
-
-function scoreCrossChannelDuplicate(
-    msg: Message<true>,
-    _member: GuildMember,
-    _context: BotContext,
-    history: readonly RecentMessage[],
-): number {
-    const normalized = msg.content.trim().toLowerCase();
-    return history.some(m => m.content === normalized && m.channelId !== msg.channelId)
-        ? SCORES.crossChannelDuplicate
-        : 0;
-}
-
-const signals: readonly Signal[] = [
-    scoreAccountAge,
-    scoreGuildJoin,
-    scoreUrl,
-    scoreDiscordInvite,
-    scoreMassUserMentions,
-    scoreRoleMentions,
-    scoreOnlyDefaultRole,
-    scoreCrossChannelDuplicate,
+const signals: readonly SignalDef[] = [
+    {
+        label: "Neues Discord-Konto (< 7 Tage alt)",
+        evaluate: (_msg, member) => {
+            const created = Temporal.Instant.fromEpochMilliseconds(member.user.createdTimestamp);
+            return isWithin(created, { hours: 7 * 24 }) ? SCORES.accountAgeUnder7Days : 0;
+        },
+    },
+    {
+        label: "Relativ neues Discord-Konto (7-30 Tage alt)",
+        evaluate: (_msg, member) => {
+            const created = Temporal.Instant.fromEpochMilliseconds(member.user.createdTimestamp);
+            return !isWithin(created, { hours: 7 * 24 }) && isWithin(created, { hours: 30 * 24 })
+                ? SCORES.accountAgeUnder30Days
+                : 0;
+        },
+    },
+    {
+        label: "Dem Server in den letzten 10 Minuten beigetreten",
+        evaluate: (_msg, member) => {
+            if (member.joinedTimestamp === null) return 0;
+            const joined = Temporal.Instant.fromEpochMilliseconds(member.joinedTimestamp);
+            return isWithin(joined, { minutes: 10 }) ? SCORES.guildJoinUnder10Minutes : 0;
+        },
+    },
+    {
+        label: "Dem Server in der letzten Stunde beigetreten",
+        evaluate: (_msg, member) => {
+            if (member.joinedTimestamp === null) return 0;
+            const joined = Temporal.Instant.fromEpochMilliseconds(member.joinedTimestamp);
+            return !isWithin(joined, { minutes: 10 }) && isWithin(joined, { hours: 1 })
+                ? SCORES.guildJoinUnder1Hour
+                : 0;
+        },
+    },
+    {
+        label: "Dem Server in den letzten 48 Stunden beigetreten",
+        evaluate: (_msg, member) => {
+            if (member.joinedTimestamp === null) return 0;
+            const joined = Temporal.Instant.fromEpochMilliseconds(member.joinedTimestamp);
+            return !isWithin(joined, { hours: 1 }) && isWithin(joined, { hours: 48 })
+                ? SCORES.guildJoinUnder48Hours
+                : 0;
+        },
+    },
+    {
+        label: "Nachricht enthält einen Link",
+        evaluate: msg => (URL_PATTERN.test(msg.content) ? SCORES.containsUrl : 0),
+    },
+    {
+        label: "Nachricht enthält einen Discord-Einladungslink",
+        evaluate: msg =>
+            DISCORD_INVITE_PATTERN.test(msg.content) ? SCORES.containsDiscordInvite : 0,
+    },
+    {
+        label: "Nachricht erwähnt mehrere Nutzer",
+        evaluate: msg => (msg.mentions.users.size >= 2 ? SCORES.massUserMentions : 0),
+    },
+    {
+        label: "Nachricht erwähnt eine oder mehrere Rollen",
+        evaluate: msg => (msg.mentions.roles.size > 0 ? SCORES.roleMentions : 0),
+    },
+    {
+        label: "Keine selbst zugewiesenen Rollen",
+        evaluate: (_msg, member) =>
+            // ≤ 2 means only @everyone + the default role, i.e. no self-assigned roles
+            member.roles.cache.size <= 2 ? SCORES.onlyDefaultRole : 0,
+    },
+    {
+        label: "Gleiche Nachricht in mehreren Kanälen gesendet",
+        evaluate: (msg, _member, _context, history) => {
+            const normalized = msg.content.trim().toLowerCase();
+            return history.some(m => m.content === normalized && m.channelId !== msg.channelId)
+                ? SCORES.crossChannelDuplicate
+                : 0;
+        },
+    },
 ];
 
 export function evaluateMessage(
     message: Message<true>,
     member: GuildMember,
     context: BotContext,
-): number {
+): EvaluationResult {
     const { timeWindowMinutes } = context.commandConfig.autoban;
-    const now = Temporal.Now.instant();
-    const windowStart = now.subtract({ minutes: timeWindowMinutes });
+    const windowStart = Temporal.Now.instant().subtract({ minutes: timeWindowMinutes });
     const history = (recentMessages.get(member.id) ?? []).filter(
         m => Temporal.Instant.compare(m.recordedAt, windowStart) > 0,
     );
 
-    return signals.reduce((total, signal) => total + signal(message, member, context, history), 0);
+    const results = signals.map(({ label, evaluate }) => ({
+        label,
+        points: evaluate(message, member, context, history),
+    }));
+
+    return {
+        score: results.reduce((sum, r) => sum + r.points, 0),
+        triggeredLabels: results.filter(r => r.points > 0).map(r => r.label),
+    };
 }
 
 export function trackMessage(

--- a/src/service/spamDetection.ts
+++ b/src/service/spamDetection.ts
@@ -16,8 +16,16 @@ type SignalEvaluate = (
     history: readonly RecentMessage[],
 ) => number;
 
+/**
+ * "identity" signals are derived purely from account/member profile data (age, join time, roles)
+ * and are capped below the ban threshold on their own - see IDENTITY_SCORE_CAP. "content" signals
+ * are derived from the message itself and are what actually pushes a score over the ban threshold.
+ */
+type SignalCategory = "identity" | "content";
+
 type SignalDef = {
     label: string;
+    category: SignalCategory;
     evaluate: SignalEvaluate;
 };
 
@@ -38,12 +46,19 @@ const SCORES = {
     guildJoinUnder1Hour: 25,
     guildJoinUnder48Hours: 20,
     containsUrl: 20,
-    containsDiscordInvite: 25,
+    containsDiscordInvite: 45,
     massUserMentions: 20,
     roleMentions: 25,
     crossChannelDuplicate: 30,
     onlyDefaultRole: 10,
 } as const;
+
+/**
+ * Ceiling for the combined score of "identity" signals alone, kept below the default banThreshold
+ * so a fresh account joining and saying hello can't be auto-banned on profile data alone -
+ * at least one "content" signal (spammy message content/behavior) must also be triggered.
+ */
+const IDENTITY_SCORE_CAP = 50;
 
 /** Returns true if `instant` occurred more recently than `duration` ago. */
 function isWithin(instant: Temporal.Instant, duration: Temporal.DurationLike): boolean {
@@ -53,15 +68,17 @@ function isWithin(instant: Temporal.Instant, duration: Temporal.DurationLike): b
 const signals: readonly SignalDef[] = [
     {
         label: "Neues Discord-Konto (< 7 Tage alt)",
+        category: "identity",
         evaluate: (_msg, member) => {
-            const created = Temporal.Instant.fromEpochMilliseconds(member.user.createdTimestamp);
+            const created = member.user.createdAt.toTemporalInstant();
             return isWithin(created, { hours: 7 * 24 }) ? SCORES.accountAgeUnder7Days : 0;
         },
     },
     {
         label: "Relativ neues Discord-Konto (7-30 Tage alt)",
+        category: "identity",
         evaluate: (_msg, member) => {
-            const created = Temporal.Instant.fromEpochMilliseconds(member.user.createdTimestamp);
+            const created = member.user.createdAt.toTemporalInstant();
             return !isWithin(created, { hours: 7 * 24 }) && isWithin(created, { hours: 30 * 24 })
                 ? SCORES.accountAgeUnder30Days
                 : 0;
@@ -69,17 +86,19 @@ const signals: readonly SignalDef[] = [
     },
     {
         label: "Dem Server in den letzten 10 Minuten beigetreten",
+        category: "identity",
         evaluate: (_msg, member) => {
-            if (member.joinedTimestamp === null) return 0;
-            const joined = Temporal.Instant.fromEpochMilliseconds(member.joinedTimestamp);
+            const joined = member.joinedAt?.toTemporalInstant();
+            if (joined === undefined) return 0;
             return isWithin(joined, { minutes: 10 }) ? SCORES.guildJoinUnder10Minutes : 0;
         },
     },
     {
         label: "Dem Server in der letzten Stunde beigetreten",
+        category: "identity",
         evaluate: (_msg, member) => {
-            if (member.joinedTimestamp === null) return 0;
-            const joined = Temporal.Instant.fromEpochMilliseconds(member.joinedTimestamp);
+            const joined = member.joinedAt?.toTemporalInstant();
+            if (joined === undefined) return 0;
             return !isWithin(joined, { minutes: 10 }) && isWithin(joined, { hours: 1 })
                 ? SCORES.guildJoinUnder1Hour
                 : 0;
@@ -87,9 +106,10 @@ const signals: readonly SignalDef[] = [
     },
     {
         label: "Dem Server in den letzten 48 Stunden beigetreten",
+        category: "identity",
         evaluate: (_msg, member) => {
-            if (member.joinedTimestamp === null) return 0;
-            const joined = Temporal.Instant.fromEpochMilliseconds(member.joinedTimestamp);
+            const joined = member.joinedAt?.toTemporalInstant();
+            if (joined === undefined) return 0;
             return !isWithin(joined, { hours: 1 }) && isWithin(joined, { hours: 48 })
                 ? SCORES.guildJoinUnder48Hours
                 : 0;
@@ -97,29 +117,35 @@ const signals: readonly SignalDef[] = [
     },
     {
         label: "Nachricht enthält einen Link",
+        category: "content",
         evaluate: msg => (URL_PATTERN.test(msg.content) ? SCORES.containsUrl : 0),
     },
     {
         label: "Nachricht enthält einen Discord-Einladungslink",
+        category: "content",
         evaluate: msg =>
             DISCORD_INVITE_PATTERN.test(msg.content) ? SCORES.containsDiscordInvite : 0,
     },
     {
         label: "Nachricht erwähnt mehrere Nutzer",
+        category: "content",
         evaluate: msg => (msg.mentions.users.size >= 2 ? SCORES.massUserMentions : 0),
     },
     {
         label: "Nachricht erwähnt eine oder mehrere Rollen",
+        category: "content",
         evaluate: msg => (msg.mentions.roles.size > 0 ? SCORES.roleMentions : 0),
     },
     {
         label: "Keine selbst zugewiesenen Rollen",
+        category: "identity",
         evaluate: (_msg, member) =>
             // ≤ 2 means only @everyone + the default role, i.e. no self-assigned roles
             member.roles.cache.size <= 2 ? SCORES.onlyDefaultRole : 0,
     },
     {
         label: "Gleiche Nachricht in mehreren Kanälen gesendet",
+        category: "content",
         evaluate: (msg, _member, _context, history) => {
             const normalized = msg.content.trim().toLowerCase();
             return history.some(m => m.content === normalized && m.channelId !== msg.channelId)
@@ -134,8 +160,8 @@ export function evaluateMessage(
     member: GuildMember,
     context: BotContext,
 ): EvaluationResult {
-    const { timeWindowMinutes } = context.commandConfig.autoban;
-    const windowStart = Temporal.Now.instant().subtract({ minutes: timeWindowMinutes });
+    const { timeWindowDuration } = context.commandConfig.autoban;
+    const windowStart = Temporal.Now.instant().subtract(timeWindowDuration);
     const history = (recentMessages.get(member.id) ?? []).filter(
         m => Temporal.Instant.compare(m.recordedAt, windowStart) > 0,
     );
@@ -146,13 +172,21 @@ export function evaluateMessage(
         recentMessages.set(member.id, history);
     }
 
-    const results = signals.map(({ label, evaluate }) => ({
+    const results = signals.map(({ label, category, evaluate }) => ({
         label,
+        category,
         points: evaluate(message, member, context, history),
     }));
 
+    const identityScore = results
+        .filter(r => r.category === "identity")
+        .reduce((sum, r) => sum + r.points, 0);
+    const contentScore = results
+        .filter(r => r.category === "content")
+        .reduce((sum, r) => sum + r.points, 0);
+
     return {
-        score: results.reduce((sum, r) => sum + r.points, 0),
+        score: Math.min(identityScore, IDENTITY_SCORE_CAP) + contentScore,
         triggeredLabels: results.filter(r => r.points > 0).map(r => r.label),
     };
 }

--- a/src/service/spamDetection.ts
+++ b/src/service/spamDetection.ts
@@ -26,7 +26,7 @@ const SCORES = {
     accountAgeUnder30Days: 15,
     guildJoinUnder10Minutes: 40,
     guildJoinUnder1Hour: 25,
-    guildJoinUnder24Hours: 10,
+    guildJoinUnder48Hours: 20,
     containsUrl: 20,
     containsDiscordInvite: 25,
     massUserMentions: 20,
@@ -57,8 +57,8 @@ function scoreGuildJoin(_msg: Message<true>, member: GuildMember): number {
     if (Temporal.Instant.compare(joined, now.subtract({ hours: 1 })) > 0) {
         return SCORES.guildJoinUnder1Hour;
     }
-    if (Temporal.Instant.compare(joined, now.subtract({ hours: 24 })) > 0) {
-        return SCORES.guildJoinUnder24Hours;
+    if (Temporal.Instant.compare(joined, now.subtract({ hours: 48 })) > 0) {
+        return SCORES.guildJoinUnder48Hours;
     }
     return 0;
 }


### PR DESCRIPTION
Das ist ne kurze gevibecodete idee. Ich schau mir das später nochmal genauer an, glaube die Scores machen so noch nicht richtig Sinn.

Idee:
- Wir machen einen Anomalie-Score für neue User um Spam-Bots zu identifizieren
- Es muss ein Threshold erreicht werden
- Dann folgt Message Delete + Ban
- Zur Sicherheit bannen wir nicht über die Discord-Funktion, sondern über unser Ban, dann kann ein irrtümlicher Ban aufgehoben werden
- Nachrichten werden in einen für Mods (+Devs?) zugänglichen Channel geschrieben für Audit-Zwecke

Feedback nehme ich aber gerne schonmal.